### PR TITLE
File metadata and Forecast reference Time Scalar to reduce post processing from lfric core

### DIFF
--- a/applications/gungho_model/example/iodef.xml
+++ b/applications/gungho_model/example/iodef.xml
@@ -10,6 +10,9 @@
   <!-- Include variable definitions -->
   <variable_definition src="../../lfric_atm/metadata/variable_def_main.xml"/>
 
+  <!-- Include scalar definitions -->
+  <scalar_definition src="../../lfric_atm/metadata/scalar_def_main.xml"/>
+
   <!-- Include axis definitions -->
   <axis_definition src="../../lfric_atm/metadata/axis_def_main.xml"/>
 

--- a/applications/gungho_model/example/iodef_climate.xml
+++ b/applications/gungho_model/example/iodef_climate.xml
@@ -10,6 +10,9 @@
   <!-- Include variable definitions -->
   <variable_definition src="$METADATA/variable_def_main.xml"/>
 
+  <!-- Include scalar definitions -->
+  <scalar_definition src="$METADATA/scalar_def_main.xml"/>
+
   <!-- Include axis definitions -->
   <axis_definition src="$METADATA/axis_def_main.xml"/>
 

--- a/applications/gungho_model/example/iodef_lam.xml
+++ b/applications/gungho_model/example/iodef_lam.xml
@@ -10,6 +10,9 @@
   <!-- Include variable definitions -->
   <variable_definition src="$METADATA/variable_def_main.xml"/>
 
+  <!-- Include scalar definitions -->
+  <scalar_definition src="$METADATA/scalar_def_main.xml"/>
+
   <!-- Include axis definitions -->
   <axis_definition src="$METADATA/axis_def_main.xml"/>
 

--- a/applications/gungho_model/example/iodef_nwp.xml
+++ b/applications/gungho_model/example/iodef_nwp.xml
@@ -10,6 +10,9 @@
   <!-- Include variable definitions -->
   <variable_definition src="$METADATA/variable_def_main.xml"/>
 
+  <!-- Include scalar definitions -->
+  <scalar_definition src="$METADATA/scalar_def_main.xml"/>
+
   <!-- Include axis definitions -->
   <axis_definition src="$METADATA/axis_def_main.xml"/>
 

--- a/applications/jedi_lfric_tests/example_forecast/iodef.xml
+++ b/applications/jedi_lfric_tests/example_forecast/iodef.xml
@@ -6,6 +6,9 @@
   <!-- Include variable definitions -->
   <variable_definition src="../../lfric_atm/metadata/variable_def_main.xml"/>
 
+  <!-- Include scalar definitions -->
+  <scalar_definition src="../../lfric_atm/metadata/scalar_def_main.xml"/>
+
   <!-- Include axis definitions -->
   <axis_definition src="../../lfric_atm/metadata/axis_def_main.xml"/>
 

--- a/applications/jules/example/iodef.xml
+++ b/applications/jules/example/iodef.xml
@@ -5,6 +5,7 @@
 
   <context id = "gungho_atm">
 
+    <scalar_definition src="../../lfric_atm/metadata/scalar_def_main.xml"/>
     <variable_definition src="../../lfric_atm/metadata/variable_def_main.xml"/>
     <axis_definition src="../../lfric_atm/metadata/axis_def_main.xml"/>
     <!-- Pressure level axes definitions -->

--- a/applications/lfric_atm/example/iodef.xml
+++ b/applications/lfric_atm/example/iodef.xml
@@ -5,6 +5,8 @@
 
   <context id = "gungho_atm">
 
+    <scalar_definition src="../metadata/scalar_def_main.xml"/>
+
     <variable_definition src="../metadata/variable_def_main.xml"/>
     <axis_definition src="../metadata/axis_def_main.xml"/>
     <!-- Pressure level axes definitions -->

--- a/applications/lfric_atm/metadata/grid_def_main.xml
+++ b/applications/lfric_atm/metadata/grid_def_main.xml
@@ -3,96 +3,115 @@
   <grid id="node_grid">
     <domain domain_ref="node"/>
     <axis axis_ref="vert_axis_full_levels"/>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="half_level_face_grid">
     <domain domain_ref="face"/>
     <axis axis_ref="vert_axis_half_levels"/>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="full_level_face_grid">
     <domain domain_ref="face"/>
     <axis axis_ref="vert_axis_full_levels"/>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="half_level_edge_grid">
     <domain domain_ref="edge"/>
     <axis axis_ref="vert_axis_half_levels"/>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="full_level_face_grid_aero_modes">
     <domain domain_ref="face"/>
     <axis axis_ref="vert_axis_full_levels"/>
     <axis axis_ref="aero_modes"/>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="full_level_face_grid_sw_bands_aero_modes">
     <domain domain_ref="face"/>
     <axis axis_ref="vert_axis_full_levels"/>
     <axis axis_ref="sw_bands_aero_modes"/>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="full_level_face_grid_lw_bands_aero_modes">
     <domain domain_ref="face"/>
     <axis axis_ref="vert_axis_full_levels"/>
     <axis axis_ref="lw_bands_aero_modes"/>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="full_level_face_grid_photolysis_pathways">
     <domain domain_ref="face"/>
     <axis axis_ref="vert_axis_full_levels"/>
     <axis axis_ref="photolysis_pathways"/>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="full_level_face_grid_photol_species">
     <domain domain_ref="face"/>
     <axis axis_ref="vert_axis_full_levels"/>
     <axis axis_ref="photol_species"/>
-  </grid>
+    <scalar scalar_ref="frt"/>
+  </grid>  
   <grid id="3D_monthly_grid">
     <domain domain_ref="face"/>
     <axis axis_ref="vert_axis_full_levels"/>
     <axis axis_ref="monthly_climatology"/>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="full_level_face_time_grid">
     <domain domain_ref="face"/>
     <axis axis_ref="vert_axis_full_levels"/>
     <axis axis_ref="lbc_axis"/>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="half_level_face_time_grid">
     <domain domain_ref="face"/>
     <axis axis_ref="vert_axis_half_levels"/>
     <axis axis_ref="lbc_axis"/>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="half_level_edge_time_grid">
     <domain domain_ref="edge"/>
     <axis axis_ref="vert_axis_half_levels"/>
     <axis axis_ref="lbc_axis"/>
+    <scalar scalar_ref="frt"/>
   </grid>
   <!-- N.B. time axis must be before multidata axis -->
   <grid id="pft_monthly_grid">
     <domain domain_ref="face"/>
     <axis axis_ref="monthly_climatology"/>
     <axis axis_ref="plant_func_types"/>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="full_level_face_grid_cloud_subcols">
     <domain domain_ref="face"/>
     <axis axis_ref="vert_axis_full_levels"/>
     <axis axis_ref="cloud_subcols"/>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="full_level_face_grid_sw_bands">
     <domain domain_ref="face"/>
     <axis axis_ref="vert_axis_full_levels"/>
     <axis axis_ref="sw_bands"/>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="full_level_face_grid_lw_bands">
     <domain domain_ref="face"/>
     <axis axis_ref="vert_axis_full_levels"/>
     <axis axis_ref="lw_bands"/>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="full_level_face_grid_sw_bands_monthly">
     <domain domain_ref="face"/>
     <axis axis_ref="vert_axis_full_levels"/>
     <axis axis_ref="monthly_climatology"/>
     <axis axis_ref="sw_bands"/>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="full_level_face_grid_lw_bands_monthly">
     <domain domain_ref="face"/>
     <axis axis_ref="vert_axis_full_levels"/>
     <axis axis_ref="monthly_climatology"/>
     <axis axis_ref="lw_bands"/>
+    <scalar scalar_ref="frt"/>
   </grid>
 
   <!-- for SURF ancillary style files -->
@@ -100,6 +119,7 @@
     <domain domain_ref="face"/>
     <axis axis_ref="snow_layers_and_tiles"/>
     <axis axis_ref="one_time_axis"/>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="one_time_seaice_grid">
     <domain domain_ref="face"/>
@@ -110,10 +130,12 @@
     <domain domain_ref="face"/>
     <axis axis_ref="land_tiles"/>
     <axis axis_ref="one_time_axis"/>
+    <scalar scalar_ref="frt"/>
   </grid>
 
   <grid id="scalar_grid">
     <axis axis_ref="scalar_axis"/>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="random_seed_grid">
     <axis axis_ref="random_seed_size"/>
@@ -127,18 +149,21 @@
     <axis axis_ref="vert_axis_full_levels" >
       <zoom_axis begin="0" n="1"/>
     </axis>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="full_level_1_face_zoom">
     <domain domain_ref="face"/>
     <axis axis_ref="vert_axis_full_levels" >
       <zoom_axis begin="1" n="1"/>
     </axis>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="half_level_1_face_zoom">
     <domain domain_ref="face"/>
     <axis axis_ref="vert_axis_half_levels" >
       <zoom_axis begin="0" n="1"/>
     </axis>
+    <scalar scalar_ref="frt"/>
   </grid>
 
   <!-- Reduce filters -->
@@ -147,11 +172,13 @@
     <scalar id="zmax">
       <reduce_axis operation="max" />
     </scalar>
+    <scalar scalar_ref="frt"/>
   </grid>
   <grid id="vert_sum_face_grid">
     <domain domain_ref="face"/>
     <scalar>
       <reduce_axis operation="sum" />
     </scalar>
+    <scalar scalar_ref="frt"/>
   </grid>
 </grid_definition>

--- a/applications/lfric_atm/metadata/scalar_def_main.xml
+++ b/applications/lfric_atm/metadata/scalar_def_main.xml
@@ -1,0 +1,3 @@
+<scalar_definition>
+  <scalar id="frt" name="forecast_reference_time" standard_name="forecast_reference_time"/>
+</scalar_definition>

--- a/applications/ngarch/example/iodef.xml
+++ b/applications/ngarch/example/iodef.xml
@@ -6,6 +6,9 @@
   <!-- In this version we have ONE context  -->
   <context id="gungho_atm">
 
+    <!-- Include scalar definitions -->
+    <scalar_definition src="./metadata/scalar_def_main.xml"/>
+
     <!-- Include variable definitions -->
     <variable_definition src="./metadata/variable_def_main.xml" />
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -30,8 +30,8 @@ lfric_apps:
     ref:
 
 lfric_core:
-    source: git@github.com:MetOffice/lfric_core.git
-    ref: 018e40c707091a4b08cb67cba5f5c4ab49303481
+    source: git@github.com:mo-marqh/lfric_core.git
+    ref: 59137504f09c8f4e28d555afde4319e5f3c81653
 
 moci:
     source: git@github.com:MetOffice/moci.git

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -30,8 +30,8 @@ lfric_apps:
     ref:
 
 lfric_core:
-    source: git@github.com:MetOffice/lfric_core.git
-    ref: 018e40c707091a4b08cb67cba5f5c4ab49303481
+    source: git@github.com:mo-marqh/lfric_core.git
+    ref: ca8f2addebde211a22ed39682698c05ccb3437f9
 
 moci:
     source: git@github.com:MetOffice/moci.git

--- a/rose-stem/app/gungho_model/file/iodef_climate.xml
+++ b/rose-stem/app/gungho_model/file/iodef_climate.xml
@@ -10,6 +10,9 @@
   <!-- Include variable definitions -->
   <variable_definition src="$METADATA/variable_def_main.xml"/>
 
+  <!-- Include scalar definitions -->
+  <scalar_definition src="$METADATA/scalar_def_main.xml"/>
+
   <!-- Include axis definitions -->
   <axis_definition src="$METADATA/axis_def_main.xml"/>
 

--- a/rose-stem/app/gungho_model/file/iodef_lam.xml
+++ b/rose-stem/app/gungho_model/file/iodef_lam.xml
@@ -10,6 +10,9 @@
   <!-- Include variable definitions -->
   <variable_definition src="$METADATA/variable_def_main.xml"/>
 
+  <!-- Include scalar definitions -->
+  <scalar_definition src="$METADATA/scalar_def_main.xml"/>
+
   <!-- Include axis definitions -->
   <axis_definition src="$METADATA/axis_def_main.xml"/>
 

--- a/rose-stem/app/gungho_model/file/iodef_nwp.xml
+++ b/rose-stem/app/gungho_model/file/iodef_nwp.xml
@@ -10,6 +10,9 @@
   <!-- Include variable definitions -->
   <variable_definition src="$METADATA/variable_def_main.xml"/>
 
+  <!-- Include scalar definitions -->
+  <scalar_definition src="$METADATA/scalar_def_main.xml"/>
+
   <!-- Include axis definitions -->
   <axis_definition src="$METADATA/axis_def_main.xml"/>
 

--- a/rose-stem/app/jedi_forecast/file/iodef.xml
+++ b/rose-stem/app/jedi_forecast/file/iodef.xml
@@ -6,6 +6,9 @@
   <!-- Include variable definitions -->
   <variable_definition src="../../lfric_atm/metadata/variable_def_main.xml"/>
 
+  <!-- Include scalar definitions -->
+  <scalar_definition src="$METADATA/scalar_def_main.xml"/>
+
   <!-- Include axis definitions -->
   <axis_definition src="../../lfric_atm/metadata/axis_def_main.xml"/>
 

--- a/rose-stem/app/jules/file/iodef.xml
+++ b/rose-stem/app/jules/file/iodef.xml
@@ -6,6 +6,7 @@
   <context id = "gungho_atm">
 
     <variable_definition src="../../lfric_atm/metadata/variable_def_main.xml"/>
+    <scalar_definition src="../../lfric_atm/metadata/scalar_def_main.xml"/>
     <axis_definition src="../../lfric_atm/metadata/axis_def_main.xml"/>
     <!-- Pressure level axes definitions -->
     <axis_definition>

--- a/rose-stem/app/lfric_atm/file/iodef_gal_clim.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_gal_clim.xml
@@ -9,6 +9,9 @@
     <!-- Include variable definitions -->
     <variable_definition src="$METADATA/variable_def_main.xml"/>
 
+    <!-- Include scalar definitions -->
+    <scalar_definition src="$METADATA/scalar_def_main.xml"/>
+
     <!-- Include axis definitions -->
     <axis_definition src="$METADATA/axis_def_main.xml"/>
     <axis_definition src="./axis_def_plev.xml"/>

--- a/rose-stem/app/lfric_atm/file/iodef_gal_clim_chem.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_gal_clim_chem.xml
@@ -9,6 +9,9 @@
     <!-- Include variable definitions -->
     <variable_definition src="$METADATA/variable_def_main.xml"/>
 
+    <!-- Include scalar definitions -->
+    <scalar_definition src="$METADATA/scalar_def_main.xml"/>
+
     <!-- Include axis definitions -->
     <axis_definition src="$METADATA/axis_def_main.xml"/>
     <axis_definition src="./axis_def_plev.xml"/>

--- a/rose-stem/app/lfric_atm/file/iodef_gal_nwp.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_gal_nwp.xml
@@ -9,6 +9,9 @@
     <!-- Include variable definitions -->
     <variable_definition src="$METADATA/variable_def_main.xml"/>
 
+    <!-- Include scalar definitions -->
+    <scalar_definition src="$METADATA/scalar_def_main.xml"/>
+
     <!-- Include axis definitions -->
     <axis_definition src="$METADATA/axis_def_main.xml"/>
     <axis_definition src="./axis_def_plev.xml"/>

--- a/rose-stem/app/lfric_atm/file/iodef_gal_nwp_coarse_aero.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_gal_nwp_coarse_aero.xml
@@ -9,6 +9,9 @@
     <!-- Include variable definitions -->
     <variable_definition src="$METADATA/variable_def_main.xml"/>
 
+    <!-- Include scalar definitions -->
+    <scalar_definition src="$METADATA/scalar_def_main.xml"/>
+
     <!-- Include axis definitions -->
     <axis_definition src="$METADATA/axis_def_main.xml"/>
     <axis_definition src="./axis_def_plev.xml"/>

--- a/rose-stem/app/lfric_atm/file/iodef_gal_nwp_cycling.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_gal_nwp_cycling.xml
@@ -9,6 +9,9 @@
     <!-- Include variable definitions -->
     <variable_definition src="$METADATA/variable_def_main.xml"/>
 
+    <!-- Include scalar definitions -->
+    <scalar_definition src="$METADATA/scalar_def_main.xml"/>
+
     <!-- Include axis definitions -->
     <axis_definition src="$METADATA/axis_def_main.xml"/>
     <axis_definition src="./axis_def_plev.xml"/>

--- a/rose-stem/app/lfric_atm/file/iodef_gal_nwp_hres.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_gal_nwp_hres.xml
@@ -9,6 +9,9 @@
     <!-- Include variable definitions -->
     <variable_definition src="$METADATA/variable_def_main.xml"/>
 
+    <!-- Include scalar definitions -->
+    <scalar_definition src="$METADATA/scalar_def_main.xml"/>
+
     <!-- Include axis definitions -->
     <axis_definition src="$METADATA/axis_def_main.xml"/>
     <axis_definition src="./axis_def_plev.xml"/>

--- a/rose-stem/app/lfric_atm/file/iodef_idealised.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_idealised.xml
@@ -9,6 +9,9 @@
     <!-- Include variable definitions -->
     <variable_definition src="$METADATA/variable_def_main.xml"/>
 
+    <!-- Include scalar definitions -->
+    <scalar_definition src="$METADATA/scalar_def_main.xml"/>
+
     <!-- Include axis definitions -->
     <axis_definition src="$METADATA/axis_def_main.xml"/>
     <axis_definition src="./axis_def_plev.xml"/>

--- a/rose-stem/app/lfric_atm/file/iodef_idealised_flexchem.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_idealised_flexchem.xml
@@ -9,6 +9,9 @@
     <!-- Include variable definitions -->
     <variable_definition src="$METADATA/variable_def_main.xml"/>
 
+    <!-- Include scalar definitions -->
+    <scalar_definition src="$METADATA/scalar_def_main.xml"/>
+
     <!-- Include axis definitions -->
     <axis_definition src="$METADATA/axis_def_main.xml"/>
     <axis_definition src="./axis_def_plev.xml"/>

--- a/rose-stem/app/lfric_atm/file/iodef_ls_and_jedi.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_ls_and_jedi.xml
@@ -9,6 +9,9 @@
     <!-- Include variable definitions -->
     <variable_definition src="$METADATA/variable_def_main.xml"/>
 
+    <!-- Include scalar definitions -->
+    <scalar_definition src="$METADATA/scalar_def_main.xml"/>
+
     <!-- Include axis definitions -->
     <axis_definition src="$METADATA/axis_def_main.xml"/>
     <axis_definition src="./axis_def_plev.xml"/>

--- a/rose-stem/app/lfric_atm/file/iodef_ral.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_ral.xml
@@ -9,6 +9,9 @@
     <!-- Include variable definitions -->
     <variable_definition src="$METADATA/variable_def_main.xml"/>
 
+    <!-- Include scalar definitions -->
+    <scalar_definition src="$METADATA/scalar_def_main.xml"/>
+
     <!-- Include axis definitions -->
     <axis_definition src="$METADATA/axis_def_main.xml"/>
     <axis_definition src="./axis_def_plev.xml"/>

--- a/rose-stem/app/lfric_atm/file/iodef_ral_ls_and_jedi.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_ral_ls_and_jedi.xml
@@ -9,6 +9,9 @@
     <!-- Include variable definitions -->
     <variable_definition src="$METADATA/variable_def_main.xml"/>
 
+    <!-- Include scalar definitions -->
+    <scalar_definition src="$METADATA/scalar_def_main.xml"/>
+
     <!-- Include axis definitions -->
     <axis_definition src="$METADATA/axis_def_main.xml"/>
     <axis_definition src="./axis_def_plev.xml"/>

--- a/rose-stem/app/lfric_atm/file/iodef_test.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_test.xml
@@ -9,6 +9,9 @@
     <!-- Include variable definitions -->
     <variable_definition src="$METADATA/variable_def_main.xml"/>
 
+    <!-- Include scalar definitions -->
+    <scalar_definition src="$METADATA/scalar_def_main.xml"/>
+
     <!-- Include axis definitions -->
     <axis_definition src="$METADATA/axis_def_main.xml"/>
     <axis_definition src="./axis_def_plev.xml"/>

--- a/rose-stem/app/ngarch/file/iodef.xml
+++ b/rose-stem/app/ngarch/file/iodef.xml
@@ -7,6 +7,9 @@
 
     <variable_definition src="$METADATA/variable_def_main.xml"/>
     <axis_definition src="$METADATA/axis_def_main.xml"/>
+    <!-- Include scalar definitions -->
+    <scalar_definition src="$METADATA/scalar_def_main.xml"/>
+
     <!-- Pressure level axes definitions -->
     <axis_definition>
       <axis id="pressure_levels" name="pressure_levels" n_glo="29" value="(0,28)[100000 95000 92500 90000 85000 70000 60000 50000 40000 30000 25000 20000 15000 10000 7000 5000 3000 2000 1000 700 500 300 200 100 70 50 30 20 10]"/>

--- a/rose-stem/app/um2lfric/file/iodef_aquaplanet_lbc_stash_list.xml
+++ b/rose-stem/app/um2lfric/file/iodef_aquaplanet_lbc_stash_list.xml
@@ -5,6 +5,10 @@
 
   <context id = "gungho_atm">
 
+    <scalar_definition>
+      <scalar id="frt" name="forecast_reference_time" standard_name="forecast_reference_time"/>
+    </scalar_definition>
+
     <axis_definition>
       <axis id="vert_axis_half_levels" name="half_levels"/>
       <axis id="vert_axis_full_levels" name="full_levels"/>
@@ -18,30 +22,37 @@
       <grid id="node_grid">
         <domain domain_ref="node"/>
         <axis axis_ref="vert_axis_full_levels"/>
+	<scalar scalar_ref="frt"/>
       </grid>
       <grid id="half_level_face_grid">
         <domain domain_ref="face"/>
         <axis axis_ref="vert_axis_half_levels"/>
+	<scalar scalar_ref="frt"/>
       </grid>
       <grid id="full_level_face_grid">
         <domain domain_ref="face"/>
         <axis axis_ref="vert_axis_full_levels"/>
+	<scalar scalar_ref="frt"/>
       </grid>
       <grid id="half_level_edge_grid">
         <domain domain_ref="edge"/>
         <axis axis_ref="vert_axis_half_levels"/>
+	<scalar scalar_ref="frt"/>
       </grid>
       <grid id="soil_levels_face_grid">
         <domain domain_ref="face"/>
         <axis axis_ref="soil_levels"/>
+	<scalar scalar_ref="frt"/>
       </grid>
       <grid id="land_tiles_face_grid">
         <domain domain_ref="face"/>
         <axis axis_ref="land_tiles"/>
+	<scalar scalar_ref="frt"/>
       </grid>
       <grid id="snow_layers_face_grid">
         <domain domain_ref="face"/>
         <axis axis_ref="snow_layers_and_tiles"/>
+	<scalar scalar_ref="frt"/>
       </grid>
     </grid_definition>
 

--- a/science/shared/source/constants/lfric_apps_version_mod.f90
+++ b/science/shared/source/constants/lfric_apps_version_mod.f90
@@ -1,0 +1,75 @@
+!-----------------------------------------------------------------------------
+! (C) Crown copyright Met Office. All rights reserved.
+! The file LICENCE, distributed with this code, contains details of the terms
+! under which the code may be used.
+!-----------------------------------------------------------------------------
+!> @brief Module containing the lfric_apps version string components and
+!> character return function (for printing & labelling).
+
+module lfric_apps_version_mod
+
+  use constants_mod,          only: i_def, l_def, str_def
+  use lfric_core_version_mod, only: lfric_core_version_char
+
+  implicit none
+
+  private
+  public lfric_apps_version_char
+
+  integer(i_def), public, parameter   :: lfric_apps_major_version = 3
+  integer(i_def), public, parameter   :: lfric_apps_minor_version = 1
+  integer(i_def), public, parameter   :: lfric_apps_patch_version = 0
+  logical(l_def), public, parameter   :: lfric_apps_release_version = .false.
+  character(2), parameter             :: prefix = 'vn'
+  character(4), parameter             :: dev_suffix = '_dev'
+
+contains
+
+  !> Return a character representation of the current version
+  !> of lfric_apps.
+  !> This will only include the patch version if it is greater than zero
+  !> and will only skip the '_dev' suffix if the release logical is .true.
+  !> e.g. 3.1, 3.1_dev, 3.1.1_dev, 3.2, 3.2_dev
+  function lfric_apps_version_char(input_major_version, input_minor_version, &
+                                   input_patch_version, input_release_version) &
+                                   result(apps_version_char)
+
+    character(str_def)                   :: apps_version_char
+    integer(i_def), intent(in), optional :: input_major_version, &
+                                            input_minor_version, &
+                                            input_patch_version
+    logical(l_def), intent(in), optional :: input_release_version
+    integer(i_def)                       :: lfric_major_version, &
+                                            lfric_minor_version, &
+                                            lfric_patch_version
+    logical(l_def)                       :: lfric_release_version
+
+    if (present(input_major_version)) then
+      lfric_major_version = input_major_version
+    else
+      lfric_major_version = lfric_apps_major_version
+    end if
+    if (present(input_minor_version)) then
+      lfric_minor_version = input_minor_version
+    else
+      lfric_minor_version = lfric_apps_minor_version
+    end if
+    if (present(input_patch_version)) then
+      lfric_patch_version = input_patch_version
+    else
+      lfric_patch_version = lfric_apps_patch_version
+    end if
+    if (present(input_release_version)) then
+      lfric_release_version = input_release_version
+    else
+      lfric_release_version = lfric_apps_release_version
+    end if
+
+    apps_version_char = lfric_core_version_char(lfric_major_version, &
+                                                lfric_minor_version, &
+                                                lfric_patch_version, &
+                                                lfric_release_version)
+
+  end function lfric_apps_version_char
+
+end module lfric_apps_version_mod

--- a/science/shared/unit-test/constants/lfric_apps_version_mod_test.pf
+++ b/science/shared/unit-test/constants/lfric_apps_version_mod_test.pf
@@ -1,0 +1,79 @@
+!-------------------------------------------------------------------------------
+! (c) Crown copyright Met Office. All rights reserved.
+! The file LICENCE, distributed with this code, contains details of the terms
+! under which the code may be used.
+!-------------------------------------------------------------------------------
+module lfric_apps_version_mod_test
+  use funit
+  use constants_mod,          only: i_def, l_def, str_def
+  use lfric_apps_version_mod, only: lfric_apps_version_char
+  implicit none
+
+  public :: test_lfric_apps_version_char_basic, &
+            test_lfric_apps_version_char_release, &
+            test_lfric_apps_version_char_patch, &
+            test_lfric_apps_version_char_patch_release
+
+contains
+
+  @Test
+  subroutine test_lfric_apps_version_char_basic()
+    character(str_def) :: apps_version_char
+    character(str_def) :: expected_apps_version_char = 'vn3.1_dev'
+    integer(i_def) :: input_major_version = 3
+    integer(i_def) :: input_minor_version = 1
+    integer(i_def) :: input_patch_version = 0
+    logical(l_def) :: input_release_version = .false.
+    apps_version_char = lfric_apps_version_char(input_major_version, &
+                                                input_minor_version, &
+                                                input_patch_version, &
+                                                input_release_version)
+    @assertEqual(expected_apps_version_char, apps_version_char)
+  end subroutine test_lfric_apps_version_char_basic
+
+  @Test
+  subroutine test_lfric_apps_version_char_release()
+    character(str_def) :: apps_version_char
+    character(str_def) :: expected_apps_version_char = 'vn3.1'
+    integer(i_def) :: input_major_version = 3
+    integer(i_def) :: input_minor_version = 1
+    integer(i_def) :: input_patch_version = 0
+    logical(l_def) :: input_release_version = .true.
+    apps_version_char = lfric_apps_version_char(input_major_version, &
+                                                input_minor_version, &
+                                                input_patch_version, &
+                                                input_release_version)
+    @assertEqual(expected_apps_version_char, apps_version_char)
+  end subroutine test_lfric_apps_version_char_release
+
+  @Test
+  subroutine test_lfric_apps_version_char_patch()
+    character(str_def) :: apps_version_char
+    character(str_def) :: expected_apps_version_char = 'vn7.2.3_dev'
+    integer(i_def) :: input_major_version = 7
+    integer(i_def) :: input_minor_version = 2
+    integer(i_def) :: input_patch_version = 3
+    logical(l_def) :: input_release_version = .false.
+    apps_version_char = lfric_apps_version_char(input_major_version, &
+                                                input_minor_version, &
+                                                input_patch_version, &
+                                                input_release_version)
+    @assertEqual(expected_apps_version_char, apps_version_char)
+  end subroutine test_lfric_apps_version_char_patch
+
+  @Test
+  subroutine test_lfric_apps_version_char_patch_release()
+    character(str_def) :: apps_version_char
+    character(str_def) :: expected_apps_version_char = 'vn7.2.3'
+    integer(i_def) :: input_major_version = 7
+    integer(i_def) :: input_minor_version = 2
+    integer(i_def) :: input_patch_version = 3
+    logical(l_def) :: input_release_version = .true.
+    apps_version_char = lfric_apps_version_char(input_major_version, &
+                                                input_minor_version, &
+                                                input_patch_version, &
+                                                input_release_version)
+    @assertEqual(expected_apps_version_char, apps_version_char)
+  end subroutine test_lfric_apps_version_char_patch_release
+
+end module lfric_apps_version_mod_test


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: @EdHone 
Code Reviewer: @ericaneininger 

<!-- To be completed by the developer -->

This change provides extra configuration to the output file metadata, using an XIOS `scalar` to define a container for a forecast reference time that will be populated by lfric_core's lfric_xios interface (see linked PR)


- linked MetOffice/lfric_core#204
- linked https://github.com/JCSDA-internal/lfric-jedi/pull/1254
- is blocked-by #446 
- is blocked-by #455 

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

(_Some checks are automatically carried out via the CI pipeline_)

- [x] I have performed a self-review of my own code
- [x] My code follows the project's style guidelines
      [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid undertanding and enhance the
      readability of the code
- [x] My changes generate no new warnings

## Testing

- [x] I have tested this change locally, using the LFRic Apps rose-stem suite
- [x] If any tests fail (rose-stem or CI) the reason is understood and
      acceptable (eg. kgo changes)
- [x] I have added tests to cover new functionality as appropriate (eg. system
      tests, unit tests, etc.)
- [x] Any new tests have been assigned an appropriate amount of compute resource
      and have tests been allocated to an appropriate testing group (i.e. the
      developer tests are for jobs which use a small amount of compute resource
      and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

# Test Suite Results - lfric_apps - scalar_frt/run5

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [scalar_frt/run5](https://cylchub/services/cylc-review/cycles/mark.hedley/?suite=scalar_frt%2Frun5) |
| Suite User | mark.hedley |
| Workflow Start | 2026-04-20T09:32:25 |
| Groups Run | developer |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| casim | [MetOffice/casim@2026.03.2](https://github.com/MetOffice/casim/tree/2026.03.2) | True |
| jules | [MetOffice/jules@2026.03.2](https://github.com/MetOffice/jules/tree/2026.03.2) | True |
| lfric_apps | [mo-marqh/lfric_apps@scalar_frt](https://github.com/mo-marqh/lfric_apps/tree/scalar_frt) | False |
| lfric_core | [mo-marqh/lfric_core@ca8f2ad](https://github.com/mo-marqh/lfric_core/tree/ca8f2ad) | True |
| moci | [MetOffice/moci@2026.03.2](https://github.com/MetOffice/moci/tree/2026.03.2) | True |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@4387949](https://github.com/MetOffice/SimSys_Scripts/tree/4387949) | True |
| socrates | [MetOffice/socrates@2026.03.2](https://github.com/MetOffice/socrates/tree/2026.03.2) | True |
| socrates-spectral | [MetOffice/socrates-spectral@2026.03.2](https://github.com/MetOffice/socrates-spectral/tree/2026.03.2) | True |
| ukca | [MetOffice/ukca@2026.03.2](https://github.com/MetOffice/ukca/tree/2026.03.2) | True |

## Task Information
<details>
<summary>:x: failed tasks - 2</summary>

| Task | State |
| :--- | :--- |
| rose_ana_lfricinputs_um2lfric-aquaplanet_lbc_azspice_gnu_fast-debug-64bit | failed |
| rose_ana_lfricinputs_um2lfric-aquaplanet_lbc_ex1a_gnu_fast-debug-64bit | failed |
</details>
:white_check_mark: succeeded tasks - 1181
<details>
<summary>:hourglass: waiting tasks - 2</summary>

| Task | State |
| :--- | :--- |
| housekeep_azspice | waiting |
| housekeep_ex1a | waiting |
</details>

## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [x] Sensitive data is properly handled (if applicable)
- [x] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [x] Performance of the code has been considered and, if applicable, suitable
      performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance
      of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise,
      Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the
      [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html)
      (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [x] Where appropriate I have updated documentation related to this change and
      confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any psyclone related code (eg. PsyKAl-lite, Kernal
      inteface, optimisation scripts, LFRic data structure code) then please
      contact the
      [tooscollabdevteam@metoffice.gov.uk](tooscollabdevteam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [x] I understand this area of code and the changes being added
- [x] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

_Please alert the code reviewer via a tag when you have approved the SR_

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
