### PR TITLE
Lfric2lfric no multi partition

### DIFF
--- a/applications/lfric2lfric/source/initialisation/lfric2lfric_init_mesh.f90
+++ b/applications/lfric2lfric/source/initialisation/lfric2lfric_init_mesh.f90
@@ -29,6 +29,8 @@ module lfric2lfric_init_mesh_mod
   use check_local_mesh_mod,        only: check_local_mesh
   use create_mesh_mod,             only: create_mesh
   use extrusion_mod,               only: extrusion_type
+  use global_mesh_collection_mod,  only: global_mesh_collection
+  use global_mesh_mod,             only: global_mesh_type
   use load_global_mesh_mod,        only: load_global_mesh
   use load_local_mesh_mod,         only: load_local_mesh
   use load_local_mesh_maps_mod,    only: load_local_mesh_maps
@@ -46,7 +48,6 @@ module lfric2lfric_init_mesh_mod
                                          create_local_mesh_maps, &
                                          create_local_mesh
   use runtime_partition_lfric_mod, only: get_partition_parameters
-  use global_mesh_collection_mod,  only: global_mesh_collection
 
   ! Lfric2lfric modules
   use lfric2lfric_config_mod,      only: regrid_method_map,                   &
@@ -124,9 +125,12 @@ subroutine init_mesh( configuration,           &
   integer(kind=i_def)              :: mesh_selection(2)
 
   ! Local variables
-  integer(kind=i_def)                 :: i
-  character(len=str_max_filename)     :: mesh_file(2)
-  integer(kind=i_def)                 :: stencil_depths(2)
+  integer(kind=i_def)              :: i
+  character(len=str_max_filename)  :: mesh_file(2)
+  integer(kind=i_def)              :: stencil_depths(2)
+
+  type(global_mesh_type), pointer  :: global_mesh_src
+  type(global_mesh_type), pointer  :: global_mesh_dst
 
   procedure(partitioner_interface), pointer :: partitioner_src => null()
   procedure(partitioner_interface), pointer :: partitioner_dst => null()
@@ -316,6 +320,12 @@ subroutine init_mesh( configuration,           &
       call load_global_mesh( mesh_file(dst), mesh_names(dst) )
       call load_global_mesh( mesh_file(src), mesh_names(src) )
     endif
+
+    global_mesh_dst => global_mesh_collection%get_global_mesh(mesh_names(dst))
+    global_mesh_src => global_mesh_collection%get_global_mesh(mesh_names(src))
+
+    call global_mesh_dst%set_partition_nmeshes(.false.)
+    call global_mesh_src%set_partition_nmeshes(.false.)
 
     ! Partition the global meshes
     !===========================================================

--- a/rose-stem/app/lfric2lfric/rose-app.conf
+++ b/rose-stem/app/lfric2lfric/rose-app.conf
@@ -835,7 +835,7 @@ wavelength=0
 
 [namelist:partitioning(destination)]
 generate_inner_halos=.false.
-mesh_target='destination'
+mesh_type='destination'
 panel_decomposition='auto'
 !!panel_xproc=0
 !!panel_yproc=0
@@ -843,7 +843,7 @@ partitioner='cubedsphere'
 
 [namelist:partitioning(source)]
 generate_inner_halos=.false.
-mesh_target='source'
+mesh_type='source'
 panel_decomposition='auto'
 !!panel_xproc=0
 !!panel_yproc=0

--- a/rose-stem/app/lfric2lfric/rose-app.conf
+++ b/rose-stem/app/lfric2lfric/rose-app.conf
@@ -835,7 +835,7 @@ wavelength=0
 
 [namelist:partitioning(destination)]
 generate_inner_halos=.false.
-mesh_type='destination'
+mesh_target='destination'
 panel_decomposition='auto'
 !!panel_xproc=0
 !!panel_yproc=0
@@ -843,7 +843,7 @@ partitioner='cubedsphere'
 
 [namelist:partitioning(source)]
 generate_inner_halos=.false.
-mesh_type='source'
+mesh_target='source'
 panel_decomposition='auto'
 !!panel_xproc=0
 !!panel_yproc=0


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: <!-- SR id, filled by author when ready for review (e.g. @octocat) -->
Code Reviewer: <!-- CR id, filled by SSD/CCD (e.g. @octocat) -->

When reading a multigrid mesh file, by default all meshes this file contains are partitioned. It would be desirable for lfric2lfric to just partition, and make checks on mesh dimensions against CPU number, on the source and destination meshes. This functionality is already present in lfric_core via the any_maps parameter of the get_partition subroutine of the panel_decomposition_type object. On the other hand, this object subroutine is not called directly in most applications, so this functionality should be made more accessible.

The solution proposed here is the creation of a logical variable in the global_mesh object, with set/get subroutines, indicating if the multiple meshes have to be partitioned. This is similar to what is presently done, where the global_mesh variable **ntarget_meshes** is used to find if there are multiple meshes. 

Other solutions have been considered, for example:
. Extracting the **any_maps** parameter of the subroutine **get_partition** contained in the object **panel_decomposition_type** in successive subroutine calls until it can be used in the calling subroutine **create_local_mesh**. This would imply large changes in both lfric_core and lfric_apps
. Doing the same as before, but using optional subroutine parameters. Although this would minimise the number of changes in lfric_core and lfric_apps, the addition of new optional subroutine parameters is discouraged.
. Make changes in lfric2lfric to use the existing **any_maps** parameter of the subroutine **get_partition**. Lfric_core would not change, but this would imply duplicating large pieces of lfric_core code in lfric2lfric.

Any other suggestion by the reviewer would be considered and tested if necessary.

This PR will not be implemented as it is duplicated. The PRs that will substitute this are:

- linked #324
- linked MetOffice/lfric_core#290

Other linked tickets: 

- linked MetOffice/lfric_core#289
- blocked-by #201 
- closes #290 
- fixes #290 

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] I have tested this change locally, using the LFRic Apps rose-stem suite
- [x] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [x] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [x] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

### trac.log

# Test Suite Results - lfric_apps - lfric2lfric_no_multi_partition/run1

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [lfric2lfric_no_multi_partition/run1](https://cylchub/services/cylc-review/cycles/juan.m.castillo/?suite=lfric2lfric_no_multi_partition%2Frun1) |
| Suite User | juan.m.castillo |
| Workflow Start | 2026-02-25T11:09:50 |
| Groups Run | all |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| casim | [MetOffice/casim@2025.12.1](https://github.com/MetOffice/casim/tree/2025.12.1) | True |
| jules | [MetOffice/jules@69aaf4d](https://github.com/MetOffice/jules/tree/69aaf4d) | True |
| lfric_apps | [ukmo-juan-castillo/lfric_apps@test_lfric2lfric_multi_CPU](https://github.com/ukmo-juan-castillo/lfric_apps/tree/test_lfric2lfric_multi_CPU) | False |
| lfric_core | [ukmo-juan-castillo/lfric_core@3a3df7d](https://github.com/ukmo-juan-castillo/lfric_core/tree/3a3df7d) | True |
| moci | [MetOffice/moci@2025.12.1](https://github.com/MetOffice/moci/tree/2025.12.1) | True |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@2025.12.1](https://github.com/MetOffice/SimSys_Scripts/tree/2025.12.1) | True |
| socrates | [MetOffice/socrates@2025.12.1](https://github.com/MetOffice/socrates/tree/2025.12.1) | True |
| socrates-spectral | [MetOffice/socrates-spectral@2025.12.1](https://github.com/MetOffice/socrates-spectral/tree/2025.12.1) | True |
| ukca | [MetOffice/ukca@2025.12.1](https://github.com/MetOffice/ukca/tree/2025.12.1) | True |

## Task Information
:white_check_mark: succeeded tasks - 1515

## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [x] Sensitive data is properly handled (if applicable)
- [x] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [x] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [x] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
