### PR TITLE
add iscrntdiag to jules macro

### DIFF
--- a/applications/adjoint_tests/rose-meta/lfric-adjoint_tests/version30_31.py
+++ b/applications/adjoint_tests/rose-meta/lfric-adjoint_tests/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/applications/gravity_wave/rose-meta/lfric-gravity_wave/version30_31.py
+++ b/applications/gravity_wave/rose-meta/lfric-gravity_wave/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/applications/gungho_model/rose-meta/lfric-gungho_model/version30_31.py
+++ b/applications/gungho_model/rose-meta/lfric-gungho_model/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/applications/jedi_lfric_tests/rose-meta/jedi_common/version30_31.py
+++ b/applications/jedi_lfric_tests/rose-meta/jedi_common/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/applications/jedi_lfric_tests/rose-meta/jedi_forecast/version30_31.py
+++ b/applications/jedi_lfric_tests/rose-meta/jedi_forecast/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/applications/jedi_lfric_tests/rose-meta/jedi_forecast_pseudo/version30_31.py
+++ b/applications/jedi_lfric_tests/rose-meta/jedi_forecast_pseudo/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/applications/jedi_lfric_tests/rose-meta/jedi_id_tlm_tests/version30_31.py
+++ b/applications/jedi_lfric_tests/rose-meta/jedi_id_tlm_tests/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/applications/jedi_lfric_tests/rose-meta/jedi_lfric_tests/version30_31.py
+++ b/applications/jedi_lfric_tests/rose-meta/jedi_lfric_tests/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/applications/jedi_lfric_tests/rose-meta/jedi_tlm_forecast_tl/version30_31.py
+++ b/applications/jedi_lfric_tests/rose-meta/jedi_tlm_forecast_tl/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/applications/jedi_lfric_tests/rose-meta/jedi_tlm_tests/version30_31.py
+++ b/applications/jedi_lfric_tests/rose-meta/jedi_tlm_tests/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/applications/jules/rose-meta/lfric-jules/version30_31.py
+++ b/applications/jules/rose-meta/lfric-jules/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/applications/lfric2lfric/rose-meta/lfric-lfric2lfric/version30_31.py
+++ b/applications/lfric2lfric/rose-meta/lfric-lfric2lfric/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/applications/lfric_atm/rose-meta/lfric-lfric_atm/version30_31.py
+++ b/applications/lfric_atm/rose-meta/lfric-lfric_atm/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "'decoupled_trans'"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/applications/lfric_coupled/rose-meta/lfric-lfric_coupled/version30_31.py
+++ b/applications/lfric_coupled/rose-meta/lfric-lfric_coupled/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/applications/linear_model/rose-meta/lfric-linear_model/version30_31.py
+++ b/applications/linear_model/rose-meta/lfric-linear_model/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/applications/name_transport/rose-meta/lfric-name_transport/version30_31.py
+++ b/applications/name_transport/rose-meta/lfric-name_transport/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/applications/ngarch/rose-meta/lfric-ngarch/version30_31.py
+++ b/applications/ngarch/rose-meta/lfric-ngarch/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/applications/shallow_water/rose-meta/lfric-shallow_water/version30_31.py
+++ b/applications/shallow_water/rose-meta/lfric-shallow_water/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/applications/transport/rose-meta/lfric-transport/version30_31.py
+++ b/applications/transport/rose-meta/lfric-transport/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/interfaces/coupled_interface/rose-meta/coupling/version30_31.py
+++ b/interfaces/coupled_interface/rose-meta/coupling/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/interfaces/jedi_lfric_interface/rose-meta/jedi_lfric_interface/version30_31.py
+++ b/interfaces/jedi_lfric_interface/rose-meta/jedi_lfric_interface/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/interfaces/jules_interface/rose-meta/jules-lfric/version30_31.py
+++ b/interfaces/jules_interface/rose-meta/jules-lfric/version30_31.py
@@ -81,7 +81,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/interfaces/jules_interface/rose-meta/jules-lsm/version30_31.py
+++ b/interfaces/jules_interface/rose-meta/jules-lsm/version30_31.py
@@ -81,7 +81,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/science/adjoint/rose-meta/lfric-adjoint/version30_31.py
+++ b/science/adjoint/rose-meta/lfric-adjoint/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/science/gungho/rose-meta/lfric-gungho/version30_31.py
+++ b/science/gungho/rose-meta/lfric-gungho/version30_31.py
@@ -82,7 +82,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"

--- a/science/linear/rose-meta/lfric-linear/version30_31.py
+++ b/science/linear/rose-meta/lfric-linear/version30_31.py
@@ -94,7 +94,7 @@ class vn30_t146(MacroUpgrade):
         self.add_setting(config, ["namelist:jules_surface", "hleaf"], "5.7e4")
         self.add_setting(config, ["namelist:jules_surface", "hwood"], "1.1e4")
         self.add_setting(
-            config, ["namelist:jules_surface", "'iscrntdiag'"], "decoupled_trans"
+            config, ["namelist:jules_surface", "iscrntdiag"], "'decoupled_trans'"
         )
         self.add_setting(
             config, ["namelist:jules_surface", "i_modiscopt"], "'on'"


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: <!-- SR id, filled by author when ready for review (e.g. @octocat) -->
Code Reviewer: @jennyhickson 

<!-- To be completed by the developer -->

#181 added the setting `iscrntdiag` to `jules_surface` but this was missed from the upgrade macro. Because of how `apply_macros` works, this was not noticed for the rose-stem apps, but will cause issues for people upgrading standalone suites. As the macros are mirrored centrally by metomi, we can just update the macro on main and this will be available when running `rose app-upgrade`.

I've tested this works by running it on the lfric example suites, using the `-M /path/to/meta` option.

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

- [ ] I have tested this change locally, using the LFRic Apps rose-stem suite
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [x] Sensitive data is properly handled (if applicable)
- [x] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
