### PR TITLE
Read access xml

### DIFF
--- a/applications/adjoint_tests/example/iodef.xml
+++ b/applications/adjoint_tests/example/iodef.xml
@@ -246,6 +246,7 @@
 
        <!-- file definition for checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="restart_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_exner" name="exner" long_name="exner_pressure" unit="1" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" operation="instant" domain_ref="checkpoint_W3" />
@@ -256,6 +257,7 @@
        <field id="restart_m_ci" name="m_ci" long_name="m_ci" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_m_s" name="m_s" long_name="m_s" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_m_g" name="m_g" long_name="m_g" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
+       </field_group>
       </file>
 
       <file id="lfric_diag" name="lfric_diag" output_freq="6h" convention="UGRID" enabled=".TRUE.">
@@ -297,6 +299,7 @@
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
 
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <field id="read_h_u" name="h_u" long_name="horizontal_wind" standard_name="horizontal_wind" unit="m s-1" grid_ref="half_level_edge_grid" operation="instant" />
         <field id="read_v_u" name="v_u" long_name="vertical_wind" standard_name="vertical_wind" unit="m s-1" grid_ref="full_level_face_grid" operation="instant" />
         <field id="read_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" operation="instant" />
@@ -306,16 +309,20 @@
         <field id="read_m_cl" name="m_cl" long_name="cloud_liquid_water_mixing_ratio"  unit="kg/kg" grid_ref="full_level_face_grid" operation="instant" />
         <field id="read_m_s" name="m_s" long_name="snow_mixing_ratio"  unit="kg/kg" grid_ref="full_level_face_grid" operation="instant" />
         <field id="read_m_r" name="m_r" long_name="rain_mixing_ratio"  unit="kg/kg" grid_ref="full_level_face_grid" operation="instant" />
+       </field_group>
       </file>
 
         <!-- ANCIL FILES -->
 
       <file id="orography_mean_ancil" name="orography_mean_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <field id="surface_altitude" name="surface_altitude" long_name="Surface altitude" unit="m" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
        <!-- LS files -->
       <file id="ls" name="ls" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <field id="ls_time" name="time" unit="seconds" operation="once" axis_ref="ls_axis" />
         <field id="ls_theta_data" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_time_grid" operation="once" />
         <field id="ls_m_v_data" name="m_v" long_name="m_v" standard_name="m_v" unit="kg/kg" grid_ref="full_level_face_time_grid" operation="once" />
@@ -327,7 +334,8 @@
         <field id="ls_u_in_w3_data" name="u_in_w3" long_name="NS wind" unit="m s-1" grid_ref="half_level_face_time_grid" operation="once"/>
         <field id="ls_v_in_w3_data" name="v_in_w3" long_name="EW wind" unit="m s-1" grid_ref="half_level_face_time_grid" operation="once"/>
         <field id="ls_w_in_wth_data" name="w_in_wth" long_name="Upward wind" unit="m s-1" grid_ref="full_level_face_time_grid" operation="once"/>
-	      <field id="ls_land_fraction_data" name="land_area_fraction" long_name="land_area_fraction" unit="1" grid_ref="one_level_face_time_grid" operation="once" />
+        <field id="ls_land_fraction_data" name="land_area_fraction" long_name="land_area_fraction" unit="1" grid_ref="one_level_face_time_grid" operation="once" />
+       </field_group>
       </file>
 
     </file_definition>

--- a/applications/gravity_wave/example/iodef.xml
+++ b/applications/gravity_wave/example/iodef.xml
@@ -74,9 +74,11 @@
 
        <!-- file definition for checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint" mode="read" output_freq="1ts" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="restart_pressure" name="pressure" long_name="air_pressure" standard_name="air_pressure" unit="Pa" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_buoyancy" name="buoyancy" long_name="buoyancy" unit="kg m s-2" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_wind" name="wind" long_name="wind" unit="m s-1" operation="instant" domain_ref="checkpoint_W2" />
+       </field_group>
       </file>
 
       <file id="lfric_diag" name="lfric_diag" output_freq="1ts" convention="UGRID" enabled=".TRUE.">

--- a/applications/gungho_model/lam_example/baroclinic/iodef.xml
+++ b/applications/gungho_model/lam_example/baroclinic/iodef.xml
@@ -238,6 +238,7 @@
 
        <!-- file definition for checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="restart_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_exner" name="exner" long_name="exner_pressure" unit="1" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" operation="instant" domain_ref="checkpoint_W3" />
@@ -248,6 +249,7 @@
        <field id="restart_m_ci" name="m_ci" long_name="m_ci" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_m_s" name="m_s" long_name="m_s" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_m_g" name="m_g" long_name="m_g" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
+       </field_group>
        </file>
 
       <file id="lfric_diag" name="lfric_diag" output_freq="6h" convention="UGRID" enabled=".TRUE.">
@@ -333,6 +335,7 @@
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
 
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="read_ew_wind_in_w3" name="ew_wind_in_w3" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_ns_wind_in_w3" name="ns_wind_in_w3" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_theta_in_wtheta" name="theta_in_wtheta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" operation="instant" />
@@ -343,23 +346,28 @@
        <field id="read_mcl_in_wtheta" name="mcl_in_wtheta" long_name="cloud_liquid_water_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_mcf_in_wtheta" name="mcf_in_wtheta" long_name="cloud_ice_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_tstar" name="tstar" long_name="surface_temperature" standard_name="surface_temperature" unit="K" domain_ref="face" operation="instant" />
+       </field_group>
       </file>
 
         <!-- ANCIL FILES -->
 
       <file id="orography_mean_ancil" name="orography_mean_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="surface_altitude" name="surface_altitude" long_name="Surface altitude" unit="m" operation="once" domain_ref="face"/>
-       </file>
+       </field_group>
+      </file>
 
        <!-- LBC files -->
-       <file id="lbc" name="lbc" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+      <file id="lbc" name="lbc" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="lbc_time" name="time" unit="seconds" operation="once" axis_ref="lbc_axis" />
        <field id="lbc_theta_data" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_time_grid" operation="once" />
        <field id="lbc_rho_data" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" grid_ref="half_level_face_time_grid" operation="once"/>
        <field id="lbc_exner_data" name="exner" long_name="exner_pressure" unit="1" grid_ref="half_level_face_time_grid" operation="once"/>
        <field id="lbc_h_u_data" name="h_u" long_name="horizontal_wind" unit="m s-1" grid_ref="half_level_edge_time_grid" operation="once"/>
        <field id="lbc_v_u_data" name="v_u" long_name="vertical_wind" standard_name="vertical_wind" unit="m s-1" grid_ref="full_level_face_time_grid" operation="once"/>
-       </file>
+       </field_group>
+      </file>
 
     </file_definition>
 

--- a/applications/gungho_model/lam_example/straka/iodef.xml
+++ b/applications/gungho_model/lam_example/straka/iodef.xml
@@ -238,6 +238,7 @@
 
        <!-- file definition for checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="restart_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_exner" name="exner" long_name="exner_pressure" unit="1" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" operation="instant" domain_ref="checkpoint_W3" />
@@ -248,7 +249,8 @@
        <field id="restart_m_ci" name="m_ci" long_name="m_ci" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_m_s" name="m_s" long_name="m_s" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_m_g" name="m_g" long_name="m_g" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
-       </file>
+       </field_group>
+      </file>
 
       <file id="lfric_diag" name="lfric_diag" output_freq="6h" convention="UGRID" enabled=".TRUE.">
 	<field_group group_ref="derived_fields" />
@@ -333,6 +335,7 @@
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
 
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="read_ew_wind_in_w3" name="ew_wind_in_w3" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_ns_wind_in_w3" name="ns_wind_in_w3" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_theta_in_wtheta" name="theta_in_wtheta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" operation="instant" />
@@ -343,23 +346,28 @@
        <field id="read_mcl_in_wtheta" name="mcl_in_wtheta" long_name="cloud_liquid_water_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_mcf_in_wtheta" name="mcf_in_wtheta" long_name="cloud_ice_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_tstar" name="tstar" long_name="surface_temperature" standard_name="surface_temperature" unit="K" domain_ref="face" operation="instant" />
+       </field_group>
       </file>
 
         <!-- ANCIL FILES -->
 
       <file id="orography_mean_ancil" name="orography_mean_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="surface_altitude" name="surface_altitude" long_name="Surface altitude" unit="m" operation="once" domain_ref="face"/>
-       </file>
+       </field_group>
+      </file>
 
        <!-- LBC files -->
-       <file id="lbc" name="lbc" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+      <file id="lbc" name="lbc" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="lbc_time" name="time" unit="seconds" operation="once" axis_ref="lbc_axis" />
        <field id="lbc_theta_data" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_time_grid" operation="once" />
        <field id="lbc_rho_data" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" grid_ref="half_level_face_time_grid" operation="once"/>
        <field id="lbc_exner_data" name="exner" long_name="exner_pressure" unit="1" grid_ref="half_level_face_time_grid" operation="once"/>
        <field id="lbc_h_u_data" name="h_u" long_name="horizontal_wind" unit="m s-1" grid_ref="half_level_edge_time_grid" operation="once"/>
        <field id="lbc_v_u_data" name="v_u" long_name="vertical_wind" standard_name="vertical_wind" unit="m s-1" grid_ref="full_level_face_time_grid" operation="once"/>
-       </file>
+       </field_group>
+      </file>
 
     </file_definition>
 

--- a/applications/jedi_lfric_tests/example/iodef.xml
+++ b/applications/jedi_lfric_tests/example/iodef.xml
@@ -253,6 +253,7 @@
 
        <!-- file definition for checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="restart_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_exner" name="exner" long_name="exner_pressure" unit="1" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" operation="instant" domain_ref="checkpoint_W3" />
@@ -263,6 +264,7 @@
        <field id="restart_m_ci" name="m_ci" long_name="m_ci" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_m_s" name="m_s" long_name="m_s" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_m_g" name="m_g" long_name="m_g" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
+       </field_group>
       </file>
 
       <file id="lfric_diag" name="lfric_diag" output_freq="6h" convention="UGRID" enabled=".TRUE.">
@@ -304,6 +306,7 @@
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
 
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <field id="read_h_u" name="h_u" long_name="horizontal_wind" standard_name="horizontal_wind" unit="m s-1" grid_ref="half_level_edge_grid" operation="instant" />
         <field id="read_v_u" name="v_u" long_name="vertical_wind" standard_name="vertical_wind" unit="m s-1" grid_ref="full_level_face_grid" operation="instant" />
         <field id="read_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" operation="instant" />
@@ -313,16 +316,20 @@
         <field id="read_m_cl" name="m_cl" long_name="cloud_liquid_water_mixing_ratio"  unit="kg/kg" grid_ref="full_level_face_grid" operation="instant" />
         <field id="read_m_s" name="m_s" long_name="cloud_snow_mixing_ratio"  unit="kg/kg" grid_ref="full_level_face_grid" operation="instant" />
         <field id="read_m_r" name="m_r" long_name="rain_mixing_ratio"  unit="kg/kg" grid_ref="full_level_face_grid" operation="instant" />
+       </field_group>
       </file>
 
         <!-- ANCIL FILES -->
 
       <file id="orography_mean_ancil" name="orography_mean_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <field id="surface_altitude" name="surface_altitude" long_name="Surface altitude" unit="m" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
        <!-- LS files -->
       <file id="ls" name="ls" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <field id="ls_time" name="time" unit="seconds" operation="once" axis_ref="ls_axis" />
         <field id="ls_theta_data" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_time_grid" operation="once" />
         <field id="ls_m_v_data" name="m_v" long_name="m_v" standard_name="m_v" unit="kg/kg" grid_ref="full_level_face_time_grid" operation="once" />
@@ -336,7 +343,8 @@
         <field id="ls_u_in_w3_data" name="u_in_w3" long_name="NS wind" unit="m s-1" grid_ref="half_level_face_time_grid" operation="once"/>
         <field id="ls_v_in_w3_data" name="v_in_w3" long_name="EW wind" unit="m s-1" grid_ref="half_level_face_time_grid" operation="once"/>
         <field id="ls_w_in_wth_data" name="w_in_wth" long_name="Upward wind" unit="m s-1" grid_ref="full_level_face_time_grid" operation="once"/>
-	      <field id="ls_land_fraction_data" name="land_area_fraction" long_name="land_area_fraction" unit="1" grid_ref="one_level_face_time_grid" operation="once" />
+        <field id="ls_land_fraction_data" name="land_area_fraction" long_name="land_area_fraction" unit="1" grid_ref="one_level_face_time_grid" operation="once" />
+       </field_group>
       </file>
 
     </file_definition>

--- a/applications/jedi_lfric_tests/example_forecast/iodef.xml
+++ b/applications/jedi_lfric_tests/example_forecast/iodef.xml
@@ -207,6 +207,7 @@
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
 
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="read_ew_wind_in_w3" name="ew_wind_in_w3" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_ns_wind_in_w3" name="ns_wind_in_w3" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_theta_in_wtheta" name="theta_in_wtheta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" operation="instant" />
@@ -217,12 +218,15 @@
        <field id="read_mcl_in_wtheta" name="mcl_in_wtheta" long_name="cloud_liquid_water_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_mcf_in_wtheta" name="mcf_in_wtheta" long_name="cloud_ice_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_tstar" name="tstar" long_name="surface_temperature" standard_name="surface_temperature" unit="K" domain_ref="face" operation="instant" />
+       </field_group>
       </file>
 
         <!-- ANCIL FILES -->
 
       <file id="orography_mean_ancil" name="orography_mean_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="surface_altitude" name="surface_altitude" long_name="Surface altitude" unit="m" operation="once" domain_ref="face"/>
+       </field_group>
        </file>
 
     </file_definition>

--- a/applications/jedi_lfric_tests/example_forecast_pseudo/iodef.xml
+++ b/applications/jedi_lfric_tests/example_forecast_pseudo/iodef.xml
@@ -36,7 +36,7 @@
 
     <field_definition prec="8" >
 
-      <field_group id="read_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts">
+      <field_group id="read_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts" read_access=".TRUE.">
         <field id="read_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" />
         <field id="read_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" grid_ref="half_level_face_grid" />
         <field id="read_exner" name="exner" long_name="exner_pressure" unit="1" grid_ref="half_level_face_grid" />

--- a/applications/jedi_lfric_tests/example_id_tlm_tests/iodef.xml
+++ b/applications/jedi_lfric_tests/example_id_tlm_tests/iodef.xml
@@ -36,7 +36,7 @@
 
     <field_definition prec="8" >
 
-      <field_group id="read_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts">
+      <field_group id="read_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts" read_access=".TRUE.">
         <field id="read_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" />
         <field id="read_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" grid_ref="half_level_face_grid" />
         <field id="read_exner" name="exner" long_name="exner_pressure" unit="1" grid_ref="half_level_face_grid" />
@@ -66,7 +66,7 @@
         <field id="write_m_s" name="m_s" long_name="snow_mixing_ratio" unit="kg kg-1" grid_ref="full_level_face_grid" />
       </field_group>
 
-      <field_group id="read_inc_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts">
+      <field_group id="read_inc_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts" read_access=".TRUE.">
         <field id="read_inc_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" />
         <field id="read_inc_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" grid_ref="half_level_face_grid" />
         <field id="read_inc_exner" name="exner" long_name="exner_pressure" unit="1" grid_ref="half_level_face_grid" />

--- a/applications/jedi_lfric_tests/example_tlm_forecast_tl/iodef.xml
+++ b/applications/jedi_lfric_tests/example_tlm_forecast_tl/iodef.xml
@@ -36,7 +36,7 @@
 
     <field_definition prec="8" >
 
-      <field_group id="read_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts">
+      <field_group id="read_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts" read_access=".TRUE.">
         <field id="read_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" />
         <field id="read_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" grid_ref="half_level_face_grid" />
         <field id="read_exner" name="exner" long_name="exner_pressure" unit="1" grid_ref="half_level_face_grid" />
@@ -66,7 +66,7 @@
         <field id="write_m_s" name="m_s" long_name="snow_mixing_ratio" unit="kg kg-1" grid_ref="full_level_face_grid" />
       </field_group>
 
-      <field_group id="read_inc_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts">
+      <field_group id="read_inc_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts" read_access=".TRUE.">
         <field id="read_inc_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" />
         <field id="read_inc_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" grid_ref="half_level_face_grid" />
         <field id="read_inc_exner" name="exner" long_name="exner_pressure" unit="1" grid_ref="half_level_face_grid" />

--- a/applications/jedi_lfric_tests/example_tlm_tests/iodef.xml
+++ b/applications/jedi_lfric_tests/example_tlm_tests/iodef.xml
@@ -36,7 +36,7 @@
 
     <field_definition prec="8" >
 
-      <field_group id="read_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts">
+      <field_group id="read_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts" read_access=".TRUE.">
         <field id="read_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" />
         <field id="read_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" grid_ref="half_level_face_grid" />
         <field id="read_exner" name="exner" long_name="exner_pressure" unit="1" grid_ref="half_level_face_grid" />
@@ -66,7 +66,7 @@
         <field id="write_m_s" name="m_s" long_name="snow_mixing_ratio" unit="kg kg-1" grid_ref="full_level_face_grid" />
       </field_group>
 
-      <field_group id="read_inc_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts">
+      <field_group id="read_inc_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts" read_access=".TRUE.">
         <field id="read_inc_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" />
         <field id="read_inc_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" grid_ref="half_level_face_grid" />
         <field id="read_inc_exner" name="exner" long_name="exner_pressure" unit="1" grid_ref="half_level_face_grid" />

--- a/applications/lfric2lfric/example/iodef.xml
+++ b/applications/lfric2lfric/example/iodef.xml
@@ -17,14 +17,14 @@
 
       <!-- File definition for LFRic checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
-
+       <field_group read_access=".TRUE.">
         <!-- Atmosphere fields -->
         <field id="restart_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" domain_ref="checkpoint_Wtheta" operation="once" />
         <field id="restart_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" domain_ref="checkpoint_W3" operation="once" />
 
         <!-- Turbulence fields -->
 	      <field id="restart_zh" name="zh" long_name="boundary_layer_depth" unit="m" domain_ref="face" operation="once" />
-
+       </field_group>
       </file>
     </file_definition>
 
@@ -33,7 +33,9 @@
       <!-- This file contains orography ancil data -->
       <!-- ANCIL FILES -->
       <file id="src_orography_mean_ancil" name="src_orography_mean_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <field id="surface_altitude" name="surface_altitude" long_name="Surface altitude" unit="m" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
     </file_definition>
@@ -71,7 +73,9 @@
       <!-- This file contains orography ancil data -->
       <!-- ANCIL FILES -->
       <file id="dst_orography_mean_ancil" name="dst_orography_mean_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <field id="surface_altitude" name="surface_altitude" long_name="Surface altitude" unit="m" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
     </file_definition>

--- a/applications/lfric_coupled/example/iodef.xml
+++ b/applications/lfric_coupled/example/iodef.xml
@@ -324,6 +324,7 @@
 
       <!-- file definition for checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="restart_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" operation="instant" domain_ref="checkpoint_Wtheta" />
 	<field id="restart_exner" name="exner" long_name="exner_pressure" unit="1" operation="instant" domain_ref="checkpoint_W3" />
 	<field id="restart_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" operation="instant" domain_ref="checkpoint_W3" />
@@ -334,6 +335,7 @@
 	<field id="restart_m_ci" name="m_ci" long_name="m_ci" unit="kg kg-1" operation="instant" domain_ref="checkpoint_Wtheta" />
 	<field id="restart_m_s" name="m_s" long_name="m_s" unit="kg kg-1" operation="instant" domain_ref="checkpoint_Wtheta" />
 	<field id="restart_m_g" name="m_g" long_name="m_g" unit="kg kg-1" operation="instant" domain_ref="checkpoint_Wtheta" />
+       </field_group>
       </file>
 
       <file id="lfric_diag" name="lfric_diag" output_freq="6h" convention="UGRID" enabled=".TRUE.">
@@ -362,6 +364,7 @@
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
 	<!-- aquaplanet fields -->
+       <field_group read_access=".TRUE.">
 	<field id="read_ew_wind_in_w3" name="ew_wind" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
 	<field id="read_ns_wind_in_w3" name="ns_wind" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
 	<field id="read_upward_wind_in_wtheta" name="upward_wind" long_name="upward_air_velocity" standard_name="upward_air_velocity" unit="m s-1" grid_ref="full_level_face_grid" operation="instant" />
@@ -379,10 +382,12 @@
 	<field id="read_z0msea" name="z0msea" long_name="sea_surface_roughness_length" unit="m" domain_ref="face" operation="instant" />
 	<field id="read_tstar" name="tstar" long_name="surface_temperature" standard_name="surface_temperature" unit="K" domain_ref="face" operation="instant" />
 	<field id="read_ozone" name="ozone" long_name="mass_fraction_of_ozone_in_air" standard_name="mass_fraction_of_ozone_in_air" unit="1" grid_ref="full_level_face_grid" operation="instant" />
+       </field_group>
       </file>
 
       <!-- ancillary files to read -->
       <file id="orography_ancil" name="orography_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="surface_altitude" name="surface_altitude" long_name="surface_altitude" unit="m" operation="once" domain_ref="face"/>
 	<field id="sd_orog" name="m01s00i034" long_name="standard_deviation_of_orography" unit="1" operation="once" domain_ref="face"/>
 	<field id="grad_xx_orog" name="m01s00i035" long_name="orographic_gradient_XX_component" unit="1" operation="once" domain_ref="face"/>
@@ -390,44 +395,60 @@
 	<field id="grad_yy_orog" name="m01s00i037" long_name="orographic_gradient_YY_component" unit="1" operation="once" domain_ref="face"/>
 	<field id="peak_to_trough_orog" name="m01s00i018" long_name="half_of_peak_to_trough_ht_of_orog" unit="1" operation="once" domain_ref="face"/>
 	<field id="silhouette_area_orog" name="m01s00i017" long_name="silhouette_orographic_roughness" unit="1" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
       <file id="land_area_ancil" name="land_area_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="land_area_fraction" name="land_area_fraction" long_name="land_area_fraction" unit="1" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
       <file id="sea_ancil" name="sea_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="sea_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
 	<field id="chloro_sea_data" name="mass_concentration_of_chlorophyll_a_in_sea_water" long_name="Mass concentration of chlorophyll A in sea water" unit="kg m-3" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+       </field_group>
       </file>
 
       <file id="sst_ancil" name="sst_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="sst_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
 	<field id="tstar_sea_data" name="surface_temperature" long_name="Sea surface temperature" unit="K" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+       </field_group>
       </file>
 
       <file id="sea_ice_ancil" name="sea_ice_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="sea_ice_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
 	<field id="sea_ice_thickness_data" name="sea_ice_thickness" long_name="sea_ice_thickness" unit="m" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
 	<field id="sea_ice_fraction_data" name="sea_ice_area_fraction" long_name="sea_ice_fraction" unit="1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+       </field_group>
       </file>
 
       <file id="albedo_vis_ancil" name="albedo_vis_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="albedo_vis_time" name="time" unit="days" operation="once" axis_ref="monthly_climatology"/>
 	<field id="albedo_obs_vis_data" name="surface_diffuse_albedo_of_photosynthetically_active_radiation_assuming_no_snow" long_name="surface_diffuse_albedo_of_photosynthetically_active_radiation_assuming_no_snow" unit="1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+       </field_group>
       </file>
 
       <file id="albedo_nir_ancil" name="albedo_nir_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="albedo_nir_time" name="time" unit="days" operation="once" axis_ref="monthly_climatology"/>
 	<field id="albedo_obs_nir_data" name="surface_diffuse_albedo_of_near_infra_red_radiation_assuming_no_snow" long_name="surface_diffuse_albedo_of_near_infra_red_radiation_assuming_no_snow" unit="1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+       </field_group>
       </file>
 
       <file id="hydtop_ancil" name="hydtop_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="mean_topog_index" name="m01s00i274" long_name="mean_topographic_index" unit="1" operation="once" domain_ref="face" />
 	<field id="stdev_topog_index" name="m01s00i275" long_name="standard_deviation_in_topographic_index" unit="1" operation="once" domain_ref="face" />
+       </field_group>
       </file>
 
       <file id="soil_ancil" name="soil_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="soil_albedo" name="soil_albedo" long_name="soil_albedo" unit="1" operation="once" domain_ref="face"/>
 	<field id="soil_carbon_content" name="soil_carbon_content" long_name="soil_carbon_content" unit="kgC m-2" operation="once" domain_ref="face"/>
 	<field id="soil_thermal_cond" name="soil_thermal_conductivity" long_name="soil_thermal_conductivity" unit="Wm-1K-1" operation="once" domain_ref="face"/>
@@ -438,26 +459,34 @@
 	<field id="soil_thermal_cap" name="soil_thermal_capacity" long_name="soil_thermal_capacity" unit="J K-1 m-3" operation="once" domain_ref="face" />
 	<field id="soil_suction_sat" name="soil_suction_at_saturation" long_name="soil_suction_at_saturation" unit="1" operation="once" domain_ref="face" />
 	<field id="clapp_horn_b" name="m01s00i207" long_name="exponent_for_soil_moisture_functions" unit="1" operation="once" domain_ref="face" />
+       </field_group>
       </file>
 
       <file id="surface_frac_ancil" name="surface_frac_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="land_tile_fraction" name="m01s00i216" long_name="fractions_of_vegetation_types" unit="1" operation="once" domain_ref="face" axis_ref="land_tiles"/>
+       </field_group>
       </file>
 
       <file id="plant_func_ancil" name="plant_func_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="plant_func_time" name="month_number" unit="months" operation="once" axis_ref="monthly_climatology"/>
 	<field id="canopy_height_data" name="canopy_height" long_name="canopy_height" unit="1" operation="once" grid_ref="pft_monthly_grid"/>
 	<field id="leaf_area_index_data" name="leaf_area_index" long_name="leaf_area_index" unit="1" operation="once" grid_ref="pft_monthly_grid"/>
+       </field_group>
       </file>
 
       <file id="ozone_ancil" name="ozone_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="ozone_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
 	<field id="ozone_data" name="mass_fraction_of_ozone_in_air" long_name="mass_fraction_of_ozone_in_air" unit="1" operation="instant" grid_ref="3D_monthly_grid"/>
+       </field_group>
       </file>
 
       <!-- The following dust fields will need adding here when available in the ancillary file: acc_sol_du, cor_sol_du, n_acc_ins, acc_ins_du, n_cor_ins, cor_ins_du -->
       <!-- Note that variable names have changed in code and will need to changed in the ancillary file in future,  e.g. OC to OM-->
       <file id="aerosols_ancil" name="aerosols_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <field id="aerosols_time" name="time" unit="days" operation="once" axis_ref="monthly_climatology"/>
         <field id="n_ait_sol_data" name="AiSo___103" long_name="aitken_mode_soluble_number" unit="particle molecule-1" operation="instant" grid_ref="3D_monthly_grid"/>
         <field id="ait_sol_su_data" name="AiSoSU_104" long_name="aitken_mode_soluble_h2so4_mmr" unit="kg kg-1" operation="instant" grid_ref="3D_monthly_grid"/>
@@ -476,6 +505,7 @@
         <field id="n_ait_ins_data" name="AiIn___119" long_name="aitken_mode_insoluble_number" unit="particle molecule-1" operation="instant" grid_ref="3D_monthly_grid"/>
         <field id="ait_ins_bc_data" name="AiInBC_120" long_name="aitken_mode_insoluble_black_carbon_mmr" unit="kg kg-1" operation="instant" grid_ref="3D_monthly_grid"/>
         <field id="ait_ins_om_data" name="AiInOC_121" long_name="aitken_mode_insoluble_organic_matter_mmr" unit="kg kg-1" operation="instant" grid_ref="3D_monthly_grid"/>
+       </field_group>
       </file>
 
     </file_definition>

--- a/applications/linear_model/example/iodef.xml
+++ b/applications/linear_model/example/iodef.xml
@@ -245,6 +245,7 @@
 
        <!-- file definition for checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="restart_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_exner" name="exner" long_name="exner_pressure" unit="1" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" operation="instant" domain_ref="checkpoint_W3" />
@@ -255,6 +256,7 @@
        <field id="restart_m_ci" name="m_ci" long_name="m_ci" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_m_s" name="m_s" long_name="m_s" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_m_g" name="m_g" long_name="m_g" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
+       </field_group>
        </file>
 
       <file id="lfric_diag" name="lfric_diag" output_freq="6h" convention="UGRID" enabled=".TRUE.">
@@ -333,6 +335,7 @@
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
 
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="read_ew_wind_in_w3" name="ew_wind_in_w3" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_ns_wind_in_w3" name="ns_wind_in_w3" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_theta_in_wtheta" name="theta_in_wtheta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" operation="instant" />
@@ -343,16 +346,20 @@
        <field id="read_mcl_in_wtheta" name="mcl_in_wtheta" long_name="cloud_liquid_water_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_mcf_in_wtheta" name="mcf_in_wtheta" long_name="cloud_ice_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_tstar" name="tstar" long_name="surface_temperature" standard_name="surface_temperature" unit="K" domain_ref="face" operation="instant" />
-      </file>
+       </field_group>
+     </file>
 
         <!-- ANCIL FILES -->
 
       <file id="orography_mean_ancil" name="orography_mean_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="surface_altitude" name="surface_altitude" long_name="Surface altitude" unit="m" operation="once" domain_ref="face"/>
-       </file>
+       </field_group>
+     </file>
 
        <!-- LS files -->
        <file id="ls" name="ls" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="ls_time" name="time" unit="seconds" operation="once" axis_ref="ls_axis" />
        <field id="ls_theta_data" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_time_grid" operation="once" />
        <field id="ls_m_v_data" name="m_v" long_name="m_v" standard_name="m_v" unit="kg/kg" grid_ref="full_level_face_time_grid" operation="once" />
@@ -365,7 +372,8 @@
        <field id="ls_exner_data" name="exner" long_name="exner_pressure" unit="1" grid_ref="half_level_face_time_grid" operation="once"/>
        <field id="ls_h_u_data" name="h_u" long_name="horizontal_wind" unit="m s-1" grid_ref="half_level_edge_time_grid" operation="once"/>
        <field id="ls_v_u_data" name="v_u" long_name="vertical_wind" standard_name="vertical_wind" unit="m s-1" grid_ref="full_level_face_time_grid" operation="once"/>
-       </file>
+       </field_group>
+     </file>
 
     </file_definition>
 

--- a/applications/linear_model/example_file/iodef.xml
+++ b/applications/linear_model/example_file/iodef.xml
@@ -230,6 +230,7 @@
 
        <!-- file definition for checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="restart_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_exner" name="exner" long_name="exner_pressure" unit="1" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" operation="instant" domain_ref="checkpoint_W3" />
@@ -240,7 +241,8 @@
        <field id="restart_m_ci" name="m_ci" long_name="m_ci" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_m_s" name="m_s" long_name="m_s" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_m_g" name="m_g" long_name="m_g" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
-       </file>
+       </field_group>
+      </file>
 
       <file id="lfric_diag" name="lfric_diag" output_freq="6h" convention="UGRID" enabled=".TRUE.">
 	<field_group group_ref="derived_fields" />
@@ -318,6 +320,7 @@
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
 
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="read_ew_wind_in_w3" name="ew_wind_in_w3" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_ns_wind_in_w3" name="ns_wind_in_w3" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_theta_in_wtheta" name="theta_in_wtheta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" operation="instant" />
@@ -328,16 +331,20 @@
        <field id="read_mcl_in_wtheta" name="mcl_in_wtheta" long_name="cloud_liquid_water_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_mcf_in_wtheta" name="mcf_in_wtheta" long_name="cloud_ice_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_tstar" name="tstar" long_name="surface_temperature" standard_name="surface_temperature" unit="K" domain_ref="face" operation="instant" />
-      </file>
+       </field_group>
+     </file>
 
         <!-- ANCIL FILES -->
 
       <file id="orography_mean_ancil" name="orography_mean_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="surface_altitude" name="surface_altitude" long_name="Surface altitude" unit="m" operation="once" domain_ref="face"/>
-       </file>
+       </field_group>
+     </file>
 
        <!-- LS files -->
        <file id="ls" name="ls" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="ls_time" name="time" unit="seconds" operation="once" axis_ref="ls_axis" />
        <field id="ls_theta_data" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_time_grid" operation="once" />
        <field id="ls_m_v_data" name="m_v" long_name="m_v" standard_name="m_v" unit="kg/kg" grid_ref="full_level_face_time_grid" operation="once" />
@@ -350,7 +357,8 @@
        <field id="ls_exner_data" name="exner" long_name="exner_pressure" unit="1" grid_ref="half_level_face_time_grid" operation="once"/>
        <field id="ls_h_u_data" name="h_u" long_name="horizontal_wind" unit="m s-1" grid_ref="half_level_edge_time_grid" operation="once"/>
        <field id="ls_v_u_data" name="v_u" long_name="vertical_wind" standard_name="vertical_wind" unit="m s-1" grid_ref="full_level_face_time_grid" operation="once"/>
-       </file>
+       </field_group>
+     </file>
 
     </file_definition>
 

--- a/applications/name_transport/example/iodef.xml
+++ b/applications/name_transport/example/iodef.xml
@@ -76,9 +76,11 @@
 
        <!-- file definition for checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint" mode="read" output_freq="1ts" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="restart_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_tracer_con" name="tracer_con" long_name="tracer_con" standard_name="tracer_con" unit="kg/kg" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_u" name="u" long_name="wind" unit="m s-1" operation="instant" domain_ref="checkpoint_W2" />
+       </field_group>
       </file>
 
       <file id="lfric_diag" name="lfric_diag" output_freq="1ts" convention="UGRID" enabled=".TRUE.">

--- a/applications/ngarch/example/iodef.xml
+++ b/applications/ngarch/example/iodef.xml
@@ -44,6 +44,7 @@
 
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <!-- Atmosphere fields -->
         <field id="read_ew_wind_in_w3" name="ew_wind" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
         <field id="read_ns_wind_in_w3" name="ns_wind" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
@@ -86,6 +87,7 @@
         <field id="read_snow_layer_liq_mass" name="tile_snow_layer_liq_mass" long_name="snow_layer_liquid_mass_on_tiles" unit="kg m-2" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles" />
         <field id="read_snow_layer_temp" name="tile_snow_layer_temp" long_name="snow_layer_temperature_on_tiles" unit="K" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles" />
         <field id="read_snow_layer_rgrain" name="tile_snow_layer_rgrain" long_name="snow_layer_grain_size_on_tiles" unit="microns" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles" />
+       </field_group>
       </file>
 
     </file_definition>

--- a/applications/shallow_water/example/iodef.xml
+++ b/applications/shallow_water/example/iodef.xml
@@ -100,10 +100,12 @@
 
        <!-- file definition for checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_swe_checkpoint" mode="read" output_freq="1ts" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="restart_geopot" name="geopot" long_name="fluid_geopotential" standard_name="geopotential" unit="m2 s-2" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_buoyancy" name="buoyancy" long_name="buoyancy" unit="kg m s-2" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_wind" name="wind" long_name="wind" unit="m s-1" operation="instant" domain_ref="checkpoint_W2" />
        <field id="restart_q" name="q" long_name="potential vorticity" standard_name="potential vorticity" unit="m-1 s-1" operation="instant" domain_ref="checkpoint_W3" />
+       </field_group>
       </file>
 
       <file id="lfric_diag" name="lfric_swe_diag" output_freq="10ts" convention="UGRID" enabled=".TRUE.">

--- a/applications/transport/example/iodef.xml
+++ b/applications/transport/example/iodef.xml
@@ -122,6 +122,7 @@
 
        <!-- file definition for checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint" mode="read" output_freq="1ts" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="restart_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_tracer_con" name="tracer_con" long_name="tracer_con" standard_name="tracer_con" unit="kg/kg" operation="instant" domain_ref="checkpoint_W3" />
@@ -134,6 +135,7 @@
        <field id="restart_wt_aerosol" name="wt_aerosol" long_name="wt_aerosol" standard_name="wt_aerosol" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_w3_aerosol" name="w3_aerosol" long_name="w3_aerosol" standard_name="w3_aerosol" unit="kg/kg" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_aerosol_wind" name="aerosol_wind" long_name="aerosol_wind" unit="m s-1" operation="instant" domain_ref="checkpoint_W2" />
+       </field_group>
       </file>
 
       <file id="lfric_diag" name="lfric_diag" output_freq="1ts" convention="UGRID" enabled=".TRUE.">

--- a/rose-stem/app/gravity_wave/file/iodef.xml
+++ b/rose-stem/app/gravity_wave/file/iodef.xml
@@ -74,9 +74,11 @@
 
        <!-- file definition for checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint" mode="read" output_freq="1ts" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="restart_pressure" name="pressure" long_name="air_pressure" standard_name="air_pressure" unit="Pa" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_buoyancy" name="buoyancy" long_name="buoyancy" unit="kg m s-2" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_wind" name="wind" long_name="wind" unit="m s-1" operation="instant" domain_ref="checkpoint_W2" />
+       </field_group>
       </file>
 
       <file id="lfric_diag" name="lfric_diag" output_freq="1ts" convention="UGRID" enabled=".TRUE.">

--- a/rose-stem/app/gungho_model/file/file_def_ancil.xml
+++ b/rose-stem/app/gungho_model/file/file_def_ancil.xml
@@ -3,7 +3,7 @@
   <!-- This file contains orography ancil data -->
   <!-- ANCIL FILES -->
   <file id="orography_mean_ancil" name="orography_mean_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
-    <field id="surface_altitude" name="surface_altitude" long_name="Surface altitude" unit="m" operation="once" domain_ref="face"/>
+    <field id="surface_altitude" name="surface_altitude" long_name="Surface altitude" unit="m" operation="once" domain_ref="face" read_access=".TRUE."/>
   </file>
 
 </file_definition>

--- a/rose-stem/app/gungho_model/file/file_def_initial.xml
+++ b/rose-stem/app/gungho_model/file/file_def_initial.xml
@@ -1,7 +1,6 @@
 <file_definition>
 
   <file id="lfric_initial" name="lfric_initial" output_freq="1ts" convention="UGRID" enabled=".TRUE.">
-    <field_group id="initial_dynamics_fields" freq_op="1ts" operation="once" enabled=".TRUE." >
       <field field_ref="init_theta"/>
       <field field_ref="init_rho"/>
       <field field_ref="init_m_v"/>
@@ -15,7 +14,6 @@
       <field field_ref="init_height_wth"/>
       <field field_ref="init_height_w2h"/>
       <field field_ref="init_height_w0"/>
-    </field_group>
   </file>
 
 </file_definition>

--- a/rose-stem/app/jedi_forecast/file/iodef.xml
+++ b/rose-stem/app/jedi_forecast/file/iodef.xml
@@ -207,6 +207,7 @@
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
 
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="read_ew_wind_in_w3" name="ew_wind_in_w3" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_ns_wind_in_w3" name="ns_wind_in_w3" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_theta_in_wtheta" name="theta_in_wtheta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" operation="instant" />
@@ -217,13 +218,16 @@
        <field id="read_mcl_in_wtheta" name="mcl_in_wtheta" long_name="cloud_liquid_water_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_mcf_in_wtheta" name="mcf_in_wtheta" long_name="cloud_ice_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_tstar" name="tstar" long_name="surface_temperature" standard_name="surface_temperature" unit="K" domain_ref="face" operation="instant" />
-      </file>
+       </field_group>
+     </file>
 
         <!-- ANCIL FILES -->
 
       <file id="orography_mean_ancil" name="orography_mean_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="surface_altitude" name="surface_altitude" long_name="Surface altitude" unit="m" operation="once" domain_ref="face"/>
-       </file>
+       </field_group>
+      </file>
 
     </file_definition>
 
@@ -264,7 +268,7 @@
 
     <field_definition prec="8" >
 
-      <field_group id="read_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts">
+      <field_group id="read_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts" read_access=".TRUE.">
         <field id="read_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" />
         <field id="read_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" grid_ref="half_level_face_grid" />
         <field id="read_u10m" name="u10m" long_name="eastward_wind_at_10m" unit="m s-1" domain_ref="face" />

--- a/rose-stem/app/jedi_forecast_pseudo/file/iodef.xml
+++ b/rose-stem/app/jedi_forecast_pseudo/file/iodef.xml
@@ -36,7 +36,7 @@
 
     <field_definition prec="8" >
 
-      <field_group id="read_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts">
+      <field_group id="read_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts" read_access=".TRUE.">
         <field id="read_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" />
         <field id="read_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" grid_ref="half_level_face_grid" />
         <field id="read_exner" name="exner" long_name="exner_pressure" unit="1" grid_ref="half_level_face_grid" />

--- a/rose-stem/app/jedi_id_tlm_tests/file/iodef.xml
+++ b/rose-stem/app/jedi_id_tlm_tests/file/iodef.xml
@@ -36,7 +36,7 @@
 
     <field_definition prec="8" >
 
-      <field_group id="read_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts">
+      <field_group id="read_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts" read_access=".TRUE.">
         <field id="read_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" />
         <field id="read_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" grid_ref="half_level_face_grid" />
         <field id="read_exner" name="exner" long_name="exner_pressure" unit="1" grid_ref="half_level_face_grid" />
@@ -66,7 +66,7 @@
         <field id="write_m_s" name="m_s" long_name="snow_mixing_ratio" unit="kg kg-1" grid_ref="full_level_face_grid" />
       </field_group>
 
-      <field_group id="read_inc_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts">
+      <field_group id="read_inc_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts" read_access=".TRUE.">
         <field id="read_inc_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" />
         <field id="read_inc_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" grid_ref="half_level_face_grid" />
         <field id="read_inc_exner" name="exner" long_name="exner_pressure" unit="1" grid_ref="half_level_face_grid" />
@@ -414,7 +414,9 @@
         <!-- ANCIL FILES -->
 
       <file id="orography_mean_ancil" name="orography_mean_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <field id="surface_altitude" name="surface_altitude" long_name="Surface altitude" unit="m" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
        <!-- LS files -->

--- a/rose-stem/app/jedi_lfric_tests/file/iodef.xml
+++ b/rose-stem/app/jedi_lfric_tests/file/iodef.xml
@@ -253,6 +253,7 @@
 
        <!-- file definition for checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" cyclic="true" enabled=".FALSE.">
+      <field_group read_access=".TRUE.">
        <field id="restart_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_exner" name="exner" long_name="exner_pressure" unit="1" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" operation="instant" domain_ref="checkpoint_W3" />
@@ -263,6 +264,7 @@
        <field id="restart_m_ci" name="m_ci" long_name="m_ci" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_m_s" name="m_s" long_name="m_s" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_m_g" name="m_g" long_name="m_g" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
+      </field_group>
       </file>
 
       <file id="lfric_diag" name="lfric_diag" output_freq="6h" convention="UGRID" enabled=".TRUE.">
@@ -304,6 +306,7 @@
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
 
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <field id="read_h_u" name="h_u" long_name="horizontal_wind" standard_name="horizontal_wind" unit="m s-1" grid_ref="half_level_edge_grid" operation="instant" />
         <field id="read_v_u" name="v_u" long_name="vertical_wind" standard_name="vertical_wind" unit="m s-1" grid_ref="full_level_face_grid" operation="instant" />
         <field id="read_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" operation="instant" />
@@ -313,12 +316,15 @@
         <field id="read_m_cl" name="m_cl" long_name="cloud_liquid_water_mixing_ratio"  unit="kg/kg" grid_ref="full_level_face_grid" operation="instant" />
         <field id="read_m_s" name="m_s" long_name="snow_mixing_ratio"  unit="kg/kg" grid_ref="full_level_face_grid" operation="instant" />
         <field id="read_m_r" name="m_r" long_name="rain_mixing_ratio"  unit="kg/kg" grid_ref="full_level_face_grid" operation="instant" />
+       </field_group>
       </file>
 
         <!-- ANCIL FILES -->
 
       <file id="orography_mean_ancil" name="orography_mean_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <field id="surface_altitude" name="surface_altitude" long_name="Surface altitude" unit="m" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
        <!-- LS files -->

--- a/rose-stem/app/jedi_tlm_forecast_tl/file/iodef.xml
+++ b/rose-stem/app/jedi_tlm_forecast_tl/file/iodef.xml
@@ -36,7 +36,7 @@
 
     <field_definition prec="8" >
 
-      <field_group id="read_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts">
+      <field_group id="read_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts" read_access=".TRUE.">
         <field id="read_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" />
         <field id="read_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" grid_ref="half_level_face_grid" />
         <field id="read_exner" name="exner" long_name="exner_pressure" unit="1" grid_ref="half_level_face_grid" />
@@ -66,7 +66,7 @@
         <field id="write_m_s" name="m_s" long_name="snow_mixing_ratio" unit="kg kg-1" grid_ref="full_level_face_grid" />
       </field_group>
 
-      <field_group id="read_inc_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts">
+      <field_group id="read_inc_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts" read_access=".TRUE.">
         <field id="read_inc_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" />
         <field id="read_inc_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" grid_ref="half_level_face_grid" />
         <field id="read_inc_exner" name="exner" long_name="exner_pressure" unit="1" grid_ref="half_level_face_grid" />
@@ -414,7 +414,9 @@
         <!-- ANCIL FILES -->
 
       <file id="orography_mean_ancil" name="orography_mean_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <field id="surface_altitude" name="surface_altitude" long_name="Surface altitude" unit="m" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
        <!-- LS files -->

--- a/rose-stem/app/jedi_tlm_tests/file/iodef.xml
+++ b/rose-stem/app/jedi_tlm_tests/file/iodef.xml
@@ -36,7 +36,7 @@
 
     <field_definition prec="8" >
 
-      <field_group id="read_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts">
+      <field_group id="read_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts" read_access=".TRUE.">
         <field id="read_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" />
         <field id="read_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" grid_ref="half_level_face_grid" />
         <field id="read_exner" name="exner" long_name="exner_pressure" unit="1" grid_ref="half_level_face_grid" />
@@ -66,7 +66,7 @@
         <field id="write_m_s" name="m_s" long_name="snow_mixing_ratio" unit="kg kg-1" grid_ref="full_level_face_grid" />
       </field_group>
 
-      <field_group id="read_inc_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts">
+      <field_group id="read_inc_fields" freq_op="1ts" enabled=".TRUE." operation="instant" freq_offset="1ts" read_access=".TRUE.">
         <field id="read_inc_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" />
         <field id="read_inc_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" grid_ref="half_level_face_grid" />
         <field id="read_inc_exner" name="exner" long_name="exner_pressure" unit="1" grid_ref="half_level_face_grid" />
@@ -414,7 +414,9 @@
         <!-- ANCIL FILES -->
 
       <file id="orography_mean_ancil" name="orography_mean_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <field id="surface_altitude" name="surface_altitude" long_name="Surface altitude" unit="m" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
        <!-- LS files -->

--- a/rose-stem/app/lfric2lfric/file/iodef.xml
+++ b/rose-stem/app/lfric2lfric/file/iodef.xml
@@ -17,6 +17,7 @@
 
       <!-- File definition for LFRic checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".TRUE.">
+       <field_group read_access=".TRUE.">
 
         <!-- Atmosphere fields -->
         <field id="restart_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" domain_ref="checkpoint_Wtheta" operation="once" />
@@ -24,7 +25,7 @@
 
         <!-- Turbulence fields -->
         <field id="restart_zh" name="zh" long_name="boundary_layer_depth" unit="m" domain_ref="face" operation="once" />
-
+       </field_group>
       </file>
     </file_definition>
   </context>

--- a/rose-stem/app/lfric2lfric/file/iodef_orography.xml
+++ b/rose-stem/app/lfric2lfric/file/iodef_orography.xml
@@ -17,6 +17,7 @@
 
       <!-- File definition for LFRic checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".TRUE.">
+       <field_group read_access=".TRUE.">
 
         <!-- Atmosphere fields -->
         <field id="restart_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" domain_ref="checkpoint_Wtheta" operation="once" />
@@ -24,7 +25,7 @@
 
         <!-- Turbulence fields -->
         <field id="restart_zh" name="zh" long_name="boundary_layer_depth" unit="m" domain_ref="face" operation="once" />
-
+       </field_group>
       </file>
     </file_definition>
 
@@ -32,7 +33,9 @@
       <!-- This file contains orography ancil data -->
       <!-- ANCIL FILES -->
       <file id="src_orography_mean_ancil" name="src_orography_mean_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <field id="surface_altitude" name="surface_altitude" long_name="Surface altitude" unit="m" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
     </file_definition>
 

--- a/rose-stem/app/lfric2lfric/file/iodef_ral.xml
+++ b/rose-stem/app/lfric2lfric/file/iodef_ral.xml
@@ -17,7 +17,7 @@
 
       <!-- File definition for LFRic checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".TRUE.">
-
+       <field_group read_access=".TRUE.">
         <!-- Atmosphere fields -->
         <field id="restart_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" domain_ref="checkpoint_Wtheta" operation="once" />
         <field id="restart_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" domain_ref="checkpoint_W3" operation="once" />
@@ -189,7 +189,7 @@
         <field id="restart_soil_moisture" name="soil_moisture" long_name="soil_moisture_content" unit="kg kg-1" domain_ref="face" axis_ref="soil_levels" operation="once" />
         <field id="restart_unfrozen_soil_moisture" name="unfrozen_soil_moisture" long_name="unfrozen_soil_moisture_proportion" unit="1" domain_ref="face" axis_ref="soil_levels" operation="once" />
         <field id="restart_frozen_soil_moisture" name="frozen_soil_moisture" long_name="frozen_soil_moisture_proportion" unit="1" domain_ref="face" axis_ref="soil_levels" operation="once" />
-
+      </field_group>
       </file>
     </file_definition>
   </context>

--- a/rose-stem/app/lfric2lfric/file/iodef_ral3.xml
+++ b/rose-stem/app/lfric2lfric/file/iodef_ral3.xml
@@ -17,6 +17,7 @@
 
       <!-- File definition for LFRic checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 
          <!-- Atmosphere fields -->
         <field id="restart_upward_wind" name="upward_wind" long_name="upward_air_velocity" unit="m s-1" grid_ref="full_level_face_grid" operation="once" />
@@ -76,7 +77,7 @@
         <field id="restart_lbc_m_cl" name="m_cl" long_name="m_cl" unit="kg kg-1" grid_ref="full_level_face_grid" operation="once" />
         <field id="restart_lbc_m_r" name="m_r" long_name="m_r" unit="kg kg-1" grid_ref="full_level_face_grid" operation="once" />
         <field id="restart_lbc_m_cf" name="m_cf" long_name="m_cf" unit="kg kg-1" grid_ref="full_level_face_grid" operation="once" />
-
+      </field_group>
       </file>
     </file_definition>
   </context>

--- a/rose-stem/app/lfric2um/file/iodef.xml
+++ b/rose-stem/app/lfric2um/file/iodef.xml
@@ -52,6 +52,7 @@
 
       <!-- File definition for lfric checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="read_ew_wind" name="ew_wind" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
 	<field id="read_ns_wind" name="ns_wind" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
 	<field id="read_upward_wind" name="upward_wind" long_name="upward_air_velocity" standard_name="upward_air_velocity" unit="m s-1" grid_ref="full_level_face_grid" operation="instant" />
@@ -69,6 +70,7 @@
 	<field id="read_z0msea" name="z0msea" long_name="sea_surface_roughness_length" unit="m" domain_ref="face" operation="instant" />
 	<field id="read_tstar" name="tstar" long_name="surface_temperature" standard_name="surface_temperature" unit="K" domain_ref="face" operation="instant" />
 	<field id="read_ozone" name="ozone" long_name="mass_fraction_of_ozone_in_air" standard_name="mass_fraction_of_ozone_in_air" unit="1" grid_ref="full_level_face_grid" operation="instant" />
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/lfric2um/file/iodef_performance.xml
+++ b/rose-stem/app/lfric2um/file/iodef_performance.xml
@@ -52,6 +52,7 @@
 
       <!-- File definition for lfric checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="read_ew_wind" name="ew_wind" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
 	<field id="read_ns_wind" name="ns_wind" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
 	<field id="read_upward_wind" name="upward_wind" long_name="upward_air_velocity" standard_name="upward_air_velocity" unit="m s-1" grid_ref="full_level_face_grid" operation="instant" />
@@ -69,6 +70,7 @@
 	<field id="read_z0msea" name="z0msea" long_name="sea_surface_roughness_length" unit="m" domain_ref="face" operation="instant" />
 	<!--<field id="read_tstar" name="tstar" long_name="surface_temperature" standard_name="surface_temperature" unit="K" domain_ref="face" operation="instant" />-->
 	<!--<field id="read_ozone" name="ozone" long_name="mass_fraction_of_ozone_in_air" standard_name="mass_fraction_of_ozone_in_air" unit="1" grid_ref="full_level_face_grid" operation="instant" />-->
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/lfric2um/file/iodef_um_lam.xml
+++ b/rose-stem/app/lfric2um/file/iodef_um_lam.xml
@@ -52,6 +52,7 @@
 
       <!-- File definition for lfric checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="read_ew_wind" name="ew_wind" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
 	<field id="read_ns_wind" name="ns_wind" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
 	<field id="read_upward_wind" name="upward_wind" long_name="upward_air_velocity" standard_name="upward_air_velocity" unit="m s-1" grid_ref="full_level_face_grid" operation="instant" />
@@ -63,6 +64,7 @@
         <field id="read_rho_r2" name="rho_r2" long_name="density*R*R" unit="1" grid_ref="half_level_face_grid" operation="instant" />
         <field id="read_qcl" name="qcl" long_name="cloud condensate specific liquid content" unit="kg/kg" grid_ref="full_level_face_grid" operation="instant" />
         <field id="read_exner" name="exner" long_name="exner pressure" unit="kg m-1 s-2" grid_ref="half_level_face_grid" operation="instant" />
+	</field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/lfric_atm/file/file_def_ancil_gal.xml
+++ b/rose-stem/app/lfric_atm/file/file_def_ancil_gal.xml
@@ -2,6 +2,7 @@
 
   <!-- Ancillary files only used by global simulations -->
   <file id="orography_subgrid_ancil" name="orography_subgrid_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="sd_orog" name="m01s00i034" long_name="standard_deviation_of_orography" unit="1" operation="once" domain_ref="face"/>
     <field id="grad_x_orog" name="m01s00i005" long_name="orographic_gradient_X_component" unit="1" operation="once" domain_ref="face"/>
     <field id="grad_y_orog" name="m01s00i006" long_name="orographic_gradient_Y_component" unit="1" operation="once" domain_ref="face"/>
@@ -10,19 +11,26 @@
     <field id="grad_yy_orog" name="m01s00i037" long_name="orographic_gradient_YY_component" unit="1" operation="once" domain_ref="face"/>
     <field id="peak_to_trough_orog" name="m01s00i018" long_name="half_of_peak_to_trough_ht_of_orog" unit="1" operation="once" domain_ref="face"/>
     <field id="silhouette_area_orog" name="m01s00i017" long_name="silhouette_orographic_roughness" unit="1" operation="once" domain_ref="face"/>
+   </field_group>
   </file>
 
   <file id="land_area_ancil" name="land_area_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="land_area_fraction" name="land_area_fraction" long_name="land_area_fraction" unit="1" operation="once" domain_ref="face"/>
+   </field_group>
   </file>
 
   <file id="hydtop_ancil" name="hydtop_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="mean_topog_index" name="topidx" long_name="mean_topographic_index" unit="1" operation="once" domain_ref="face" />
     <field id="stdev_topog_index" name="standard_deviation_topographic_index" long_name="standard_deviation_in_topographic_index" unit="1" operation="once" domain_ref="face" />
+   </field_group>
   </file>
 
   <file id="surface_frac_ancil" name="surface_frac_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="land_tile_fraction" name="vegetation_area_fraction" long_name="fractions_of_vegetation_types" unit="1" operation="once" domain_ref="face" axis_ref="land_tiles"/>
+   </field_group>
   </file>
 
 </file_definition>

--- a/rose-stem/app/lfric_atm/file/file_def_ancil_hadisst.xml
+++ b/rose-stem/app/lfric_atm/file/file_def_ancil_hadisst.xml
@@ -2,14 +2,18 @@
 
   <!-- Ancillary files for HadISST climatology -->
   <file id="sst_ancil" name="sst_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="sst_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="tstar_sea_data" name="surface_temperature" long_name="Sea surface temperature" unit="K" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+   </field_group>
   </file>
 
   <file id="sea_ice_ancil" name="sea_ice_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="sea_ice_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="sea_ice_thickness_data" name="sea_ice_thickness" long_name="sea_ice_thickness" unit="m" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
     <field id="sea_ice_fraction_data" name="sea_ice_area_fraction" long_name="sea_ice_fraction" unit="1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+   </field_group>
   </file>
 
 

--- a/rose-stem/app/lfric_atm/file/file_def_ancil_idealised.xml
+++ b/rose-stem/app/lfric_atm/file/file_def_ancil_idealised.xml
@@ -2,6 +2,7 @@
 
   <!-- Ancillary files applicable to idealised setups -->
   <file id="gas_mmr_ancil" name="gas_mmr_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="ch4" name="ch4" long_name="mass_fraction_of_methane_in_air" unit="kg kg-1" operation="once" grid_ref="full_level_face_grid" />
     <field id="co" name="co" long_name="mass_fraction_of_carbon_monoxide_in_air" unit="kg kg-1" operation="once" grid_ref="full_level_face_grid" />
     <field id="co2" name="co2" long_name="mass_fraction_of_carbon_dioxide_in_air" unit="kg kg-1" operation="once" grid_ref="full_level_face_grid" />
@@ -16,10 +17,13 @@
     <!-- <field id="rb" name="rb" long_name="mass_fraction_of_rubidium_in_air" unit="kg kg-1" operation="once" grid_ref="full_level_face_grid" /> -->
     <!-- <field id="tio" name="tio" long_name="mass_fraction_of_titanium_oxide_in_air" unit="kg kg-1" operation="once" grid_ref="full_level_face_grid" /> -->
     <!-- <field id="vo" name="vo" long_name="mass_fraction_of_vanadium_oxide_in_air" unit="kg kg-1" operation="once" grid_ref="full_level_face_grid" /> -->
+   </field_group>
   </file>
 
   <file id="int_flux_ancil" name="int_flux_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="internal_flux" name="internal_flux" long_name="internal_flux" unit="W m-2" operation="once" domain_ref="face" />
+   </field_group>
   </file>
 
 </file_definition>

--- a/rose-stem/app/lfric_atm/file/file_def_ancil_main.xml
+++ b/rose-stem/app/lfric_atm/file/file_def_ancil_main.xml
@@ -2,25 +2,34 @@
 
   <!-- Ancillary files applicable to all setups -->
   <file id="orography_mean_ancil" name="orography_mean_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="surface_altitude" name="surface_altitude" long_name="surface_altitude" unit="m" operation="once" domain_ref="face"/>
+   </field_group>
   </file>
 
   <file id="sea_ancil" name="sea_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="sea_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="chloro_sea_data" name="mass_concentration_of_chlorophyll_a_in_sea_water" long_name="Mass concentration of chlorophyll A in sea water" unit="kg m-3" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+   </field_group>
   </file>
 
   <file id="albedo_vis_ancil" name="albedo_vis_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="albedo_vis_time" name="time" unit="days" operation="once" axis_ref="monthly_climatology"/>
     <field id="albedo_obs_vis_data" name="surface_diffuse_albedo_of_photosynthetically_active_radiation_assuming_no_snow" long_name="surface_diffuse_albedo_of_photosynthetically_active_radiation_assuming_no_snow" unit="1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+   </field_group>
   </file>
 
   <file id="albedo_nir_ancil" name="albedo_nir_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="albedo_nir_time" name="time" unit="days" operation="once" axis_ref="monthly_climatology"/>
     <field id="albedo_obs_nir_data" name="surface_diffuse_albedo_of_near_infra_red_radiation_assuming_no_snow" long_name="surface_diffuse_albedo_of_near_infra_red_radiation_assuming_no_snow" unit="1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+   </field_group>
   </file>
 
   <file id="soil_ancil" name="soil_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="soil_albedo" name="soil_albedo" long_name="soil_albedo" unit="1" operation="once" domain_ref="face"/>
     <field id="soil_thermal_cond" name="soil_thermal_conductivity" long_name="soil_thermal_conductivity" unit="Wm-1K-1" operation="once" domain_ref="face"/>
     <field id="soil_moist_wilt" name="volume_fraction_of_condensed_water_in_soil_at_wilting_point" long_name="soil_moisture_at_wilting_point" unit="m3 m-3" operation="once" domain_ref="face" />
@@ -30,32 +39,42 @@
     <field id="soil_thermal_cap" name="soil_thermal_capacity" long_name="soil_thermal_capacity" unit="J K-1 m-3" operation="once" domain_ref="face" />
     <field id="soil_suction_sat" name="soil_suction_at_saturation" long_name="soil_suction_at_saturation" unit="1" operation="once" domain_ref="face" />
     <field id="clapp_horn_b" name="m01s00i207" long_name="exponent_for_soil_moisture_functions" unit="1" operation="once" domain_ref="face" />
+   </field_group>
   </file>
 
   <file id="soil_rough_ancil" name="soil_rough_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="soil_roughness" name="surface_roughness_length" long_name="soil_surface_roughness_length" unit="m" operation="once" domain_ref="face"/>
+   </field_group>
   </file>
 
   <file id="urban_ancil" name="urban_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="urbwrr" name="urbwrr" long_name="Urban width repeating ratio" unit="1" operation="once" domain_ref="face"/>
     <field id="urbhwr" name="urbhwr" long_name="Urban height-to-width ratio" unit="1" operation="once" domain_ref="face"/>
     <field id="urbhgt" name="urbhgt" long_name="Urban building height" unit="1" operation="once" domain_ref="face"/>
+   </field_group>
   </file>
 
   <file id="plant_func_ancil" name="plant_func_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="plant_func_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="canopy_height_data" name="canopy_height" long_name="canopy_height" unit="1" operation="once" grid_ref="pft_monthly_grid"/>
     <field id="leaf_area_index_data" name="leaf_area_index" long_name="leaf_area_index" unit="1" operation="once" grid_ref="pft_monthly_grid"/>
+   </field_group>
   </file>
 
   <file id="ozone_ancil" name="ozone_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="ozone_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="ozone_data" name="mass_fraction_of_ozone_in_air" long_name="mass_fraction_of_ozone_in_air" unit="1" operation="instant" grid_ref="variable_3D_monthly_grid"/>
+   </field_group>
   </file>
 
   <!-- The following dust fields will need adding here when available in the ancillary file: acc_sol_du, cor_sol_du, n_acc_ins, acc_ins_du, n_cor_ins, cor_ins_du -->
   <!-- Note that variable names have changed in code and will need to changed in the ancillary file in future,  e.g. OC to OM-->
   <file id="aerosols_ancil" name="aerosols_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="aerosols_time" name="time" unit="days" operation="once" axis_ref="monthly_climatology"/>
     <field id="n_ait_sol_data" name="AiSo___103" long_name="aitken_soluble_mode_number" unit="1" operation="once" grid_ref="variable_3D_monthly_grid"/>
     <field id="ait_sol_su_data" name="AiSoSU_104" long_name="aitken_soluble_mode_h2so4_mmr" unit="kg kg-1" operation="once" grid_ref="variable_3D_monthly_grid"/>
@@ -74,68 +93,93 @@
     <field id="n_ait_ins_data" name="AiIn___119" long_name="aitken_insoluble_mode_number" unit="1" operation="once" grid_ref="variable_3D_monthly_grid"/>
     <field id="ait_ins_bc_data" name="AiInBC_120" long_name="aitken_insoluble_mode_black_carbon_mmr" unit="kg kg-1" operation="once" grid_ref="variable_3D_monthly_grid"/>
     <field id="ait_ins_om_data" name="AiInOC_121" long_name="aitken_insoluble_mode_organic_matter_mmr" unit="kg kg-1" operation="once" grid_ref="variable_3D_monthly_grid"/>
+   </field_group>
   </file>
 
   <!-- UKCA emission files -->
      <file id="emiss_c2h6_ancil" name="emiss_c2h6_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+     <field_group read_access=".TRUE.">
       <field id="em_c2h6_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
       <field id="emiss_c2h6_data" name="emissions_C2H6" long_name="C2H6 surf emissions" unit="kg m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
-      </file>
+     </field_group>
+     </file>
 
      <file id="emiss_c3h8_ancil" name="emiss_c3h8_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+     <field_group read_access=".TRUE.">
       <field id="em_c3h8_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
       <field id="emiss_c3h8_data" name="emissions_C3H8" long_name="C3H8 surf emissions" unit="kg m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
-      </file>
+     </field_group>
+     </file>
 
      <file id="emiss_c5h8_ancil" name="emiss_c5h8_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+     <field_group read_access=".TRUE.">
       <field id="em_c5h8_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
       <field id="emiss_c5h8_data" name="emissions_C5H8" long_name="Biogenic surface C5H8 emissions" unit="kg m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
-      </file>
+     </field_group>
+     </file>
 
      <file id="emiss_ch4_ancil" name="emiss_ch4_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+     <field_group read_access=".TRUE.">
       <field id="em_ch4_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
       <field id="emiss_ch4_data" name="emissions_CH4" long_name="CH4 surf emissions" unit="kg m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
-      </file>
+     </field_group>
+     </file>
 
      <file id="emiss_co_ancil" name="emiss_co_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+     <field_group read_access=".TRUE.">
       <field id="em_co_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
       <field id="emiss_co_data" name="emissions_CO" long_name="CO surf emissions" unit="kg m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
-      </file>
+     </field_group>
+     </file>
 
      <file id="emiss_hcho_ancil" name="emiss_hcho_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+     <field_group read_access=".TRUE.">
       <field id="em_hcho_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
       <field id="emiss_hcho_data" name="emissions_HCHO" long_name="HCHO surf emissions" unit="kg m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
-      </file>
+     </field_group>
+     </file>
 
      <file id="emiss_me2co_ancil" name="emiss_me2co_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+     <field_group read_access=".TRUE.">
       <field id="em_me2co_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
       <field id="emiss_me2co_data" name="emissions_Me2CO" long_name="Me2CO surf emissions" unit="kg m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
-      </file>
+     </field_group>
+     </file>
 
      <file id="emiss_mecho_ancil" name="emiss_mecho_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+     <field_group read_access=".TRUE.">
       <field id="em_mecho_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
       <field id="emiss_mecho_data" name="emissions_MeCHO" long_name="MeCHO surf emissions" unit="kg m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
-      </file>
+     </field_group>
+     </file>
 
      <file id="emiss_nh3_ancil" name="emiss_nh3_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+     <field_group read_access=".TRUE.">
       <field id="em_nh3_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
       <field id="emiss_nh3_data" name="emissions_NH3" long_name="ammonia gas emissions" unit="kg m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
-      </file>
+     </field_group>
+     </file>
 
      <file id="emiss_no_ancil" name="emiss_no_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+     <field_group read_access=".TRUE.">
       <field id="em_no_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
       <field id="emiss_no_data" name="emissions_NO" long_name="NOx surface emissions" unit="kg m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
-      </file>
+     </field_group>
+     </file>
 
      <file id="emiss_meoh_ancil" name="emiss_meoh_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+     <field_group read_access=".TRUE.">
       <field id="em_meoh_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
       <field id="emiss_meoh_data" name="emissions_MeOH" long_name="Biogenic surface methanol (CH3OH) emissions" unit="kg m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
-      </file>
+     </field_group>
+     </file>
 
      <file id="emiss_no_aircrft_ancil" name="emiss_no_aircrft_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+     <field_group read_access=".TRUE.">
       <field id="em_no_aircrft_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
       <field id="emiss_no_aircrft_data" name="emissions_NO_aircrft" long_name="NOx aircraft emissions" unit="kg m-2 s-1" operation="instant" grid_ref="3D_monthly_grid"/>
-      </file>
+     </field_group>
+     </file>
 
   <file id="emiss_bc_biofuel_ancil" name="emiss_bc_biofuel_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
     <field id="em_bc_bf_time" name="time" unit="days" operation="once" axis_ref="emiss_axis"/>
@@ -148,8 +192,10 @@
   </file>
 
   <file id="emiss_bc_biomass_ancil" name="emiss_bc_biomass_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="em_bc_bb_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="emiss_bc_biomass_data" name="emissions_BC_biomass" long_name="BC biomass 3D emissions" unit="kg m-2 s-1" operation="instant" grid_ref="3D_monthly_grid"/>
+   </field_group>
   </file>
 
   <file id="emiss_bc_biomass_hi_ancil" name="emiss_bc_biomass_hi_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
@@ -163,18 +209,24 @@
   </file>
 
   <file id="emiss_dms_land_ancil" name="emiss_dms_land_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="em_dms_lnd_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="emiss_dms_land_data" name="emissions_DMS" long_name="DMS emissions expressed as sulfur" unit="kg(S) m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+   </field_group>
   </file>
 
   <file id="dms_conc_ocean_ancil" name="dms_conc_ocean_ancil"  mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="dms_ocn_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="dms_conc_ocean_data" name="mole_concentration_of_dimethyl_sulfide_in_sea_water" long_name="mole_concentration_of_dimethyl_sulfide_in_sea_water" unit="nmoles l-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+   </field_group>
   </file>
 
   <file id="emiss_monoterp_ancil" name="emiss_monoterp_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="em_mterp_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="emiss_monoterp_data" name="emissions_Monoterp" long_name="Monoterpene surf emissions expressed as carbon" unit="kg(C) m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+   </field_group>
   </file>
 
   <file id="emiss_om_biofuel_ancil" name="emiss_om_biofuel_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
@@ -188,8 +240,10 @@
   </file>
 
   <file id="emiss_om_biomass_ancil" name="emiss_om_biomass_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="em_om_bb_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="emiss_om_biomass_data" name="emissions_OC_biomass" long_name="OC biomass 3D emissions expressed as carbon" unit="kg(C) m-2 s-1" operation="instant" grid_ref="3D_monthly_grid"/>
+   </field_group>
   </file>
 
   <file id="emiss_om_biomass_hi_ancil" name="emiss_om_biomass_hi_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
@@ -208,52 +262,71 @@
   </file>
 
   <file id="emiss_so2_high_ancil" name="emiss_so2_high_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="em_so2_hi_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="emiss_so2_high_data" name="emissions_SO2_high" long_name="SO2 high level emissions expressed as sulfur" unit="kg(S) m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+   </field_group>
   </file>
 
   <file id="emiss_so2_nat_ancil" name="emiss_so2_nat_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="emiss_so2_nat" name="emissions_SO2_nat_kgSO2" long_name="SO2 natural emissions" unit="kg(SO2) m-2 s-1" operation="once" grid_ref="full_level_face_grid"/>
+   </field_group>
   </file>
 
   <file id="soil_dust_ancil" name="soil_dust_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="soil_clay" name="volume_fraction_of_clay_in_soil" long_name="volume_fraction_of_clay_in_soil" unit="m3 m-3" operation="once" domain_ref="face"/>
     <field id="soil_sand" name="volume_fraction_of_sand_in_soil" long_name="volume_fraction_of_sand_in_soil" unit="m3 m-3" operation="once" domain_ref="face"/>
     <field id="dust_mrel" name="mass_fraction_of_dust_in_size_bins" long_name="mass_fraction_of_dust_in_size_bins" unit="kg kg-1" operation="once" domain_ref="face" axis_ref="dust_divisions" />
+   </field_group>
   </file>
 
   <file id="emiss_murk_ancil" name="emiss_murk_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="murk_time" name="time"  unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="murk_source_data" name="m01s00i057" long_name="emissions_of_murk_aerosol" unit="kg m-2 s-1" operation="instant" grid_ref="3D_monthly_grid"/>
+   </field_group>
   </file>
 
   <!--- UKCA Offline Oxidant ancils -->
   <file id="h2o2_limit_ancil" name="h2o2_limit_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="h2o2_limit_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="h2o2_limit_data" name="H2O2" long_name="H2O2 mass mixing ratio" unit="1" operation="instant" grid_ref="3D_monthly_grid"/>
+   </field_group>
   </file>
 
   <file id="ho2_ancil" name="ho2_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="ho2_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="ho2_data" name="HO2" long_name="HO2 mass mixing ratio" unit="1" operation="instant" grid_ref="3D_monthly_grid"/>
+   </field_group>
   </file>
 
   <file id="no3_ancil" name="no3_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="no3_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="no3_data" name="NO3" long_name="NO3 mass mixing ratio" unit="1" operation="instant" grid_ref="3D_monthly_grid"/>
+   </field_group>
   </file>
 
   <file id="o3_ancil" name="o3_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="o3_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="o3_data" name="O3" long_name="O3 mass mixing ratio" unit="1" operation="instant" grid_ref="3D_monthly_grid"/>
+   </field_group>
   </file>
 
   <file id="oh_ancil" name="oh_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="oh_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="oh_data" name="OH" long_name="OH mass mixing ratio" unit="1" operation="instant" grid_ref="3D_monthly_grid"/>
+   </field_group>
   </file>
 
   <file id="snow_analysis_ancil" name="snow_analysis_ancil" mode="read" output_freq="1mo"  convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="snow_time" name="time" unit="hours" operation="once" axis_ref="one_time_axis"/>
     <field id="tile_snow_rgrain_in_data" name="tile_snow_rgrain" long_name="tile_snow_grain_size" unit="microns" operation="instant" grid_ref="one_time_tile_grid"/>
     <field id="tile_snow_mass_in_data" name="tile_snow_mass" long_name="tile_snow_mass" unit="kg m-2"  operation="instant" grid_ref="one_time_tile_grid"/>
@@ -266,36 +339,51 @@
     <field id="snow_layer_ice_mass_data" name="snow_layer_ice_mass" long_name="snow_layer_ice_mass" unit="kg m-2" operation="instant" grid_ref="one_time_snow_layer_tile_grid"/>
     <field id="snow_layer_liq_mass_data" name="snow_layer_liq_mass" long_name="snow_layer_liquid_mass" unit="kg m-2" operation="instant" grid_ref="one_time_snow_layer_tile_grid"/>
     <field id="snow_layer_rgrain_data" name="snow_layer_rgrain" long_name="snow_layer_grain_size" unit="microns" operation="instant" grid_ref="one_time_snow_layer_tile_grid"/>
+   </field_group>
   </file>
 
   <!--- Easy Aerosol ancils -->
   <file id="cloud_drop_no_conc_ancil" name="cloud_drop_no_conc_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="cloud_drop_no_conc_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="cloud_drop_no_conc_data" name="cloud_drop_no_conc" long_name="cloud_droplet_number_concentration" unit="m-3" operation="instant" grid_ref="3D_monthly_grid"/>
+   </field_group>
   </file>
   <file id="easy_asymmetry_sw_ancil" name="easy_asymmetry_sw_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="easy_asymmetry_sw_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="easy_asymmetry_sw_data" name="easy_asymmetry_sw" long_name="asymmetry parameter of EasyAerosol" unit="1" operation="instant" grid_ref="full_level_face_grid_sw_bands_monthly"/>
+   </field_group>
   </file>
   <file id="easy_asymmetry_lw_ancil" name="easy_asymmetry_lw_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="easy_asymmetry_lw_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="easy_asymmetry_lw_data" name="easy_asymmetry_lw" long_name="asymmetry parameter of EasyAerosol" unit="1" operation="instant" grid_ref="full_level_face_grid_lw_bands_monthly"/>
+   </field_group>
   </file>
   <file id="easy_absorption_sw_ancil" name="easy_absorption_sw_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="easy_absorption_sw_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="easy_absorption_sw_data" name="easy_absorption_sw" long_name="absorption coefficient of EasyAerosol" unit="m-1" operation="instant" grid_ref="full_level_face_grid_sw_bands_monthly"/>
+   </field_group>
   </file>
   <file id="easy_absorption_lw_ancil" name="easy_absorption_lw_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="easy_absorption_lw_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="easy_absorption_lw_data" name="easy_absorption_lw" long_name="absorption coefficient of EasyAerosol" unit="m-1" operation="instant" grid_ref="full_level_face_grid_lw_bands_monthly"/>
+   </field_group>
   </file>
   <file id="easy_extinction_sw_ancil" name="easy_extinction_sw_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="easy_extinction_sw_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="easy_extinction_sw_data" name="easy_extinction_sw" long_name="extinction coefficient of EasyAerosol" unit="m-1" operation="instant" grid_ref="full_level_face_grid_sw_bands_monthly"/>
+   </field_group>
   </file>
   <file id="easy_extinction_lw_ancil" name="easy_extinction_lw_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="easy_extinction_lw_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
     <field id="easy_extinction_lw_data" name="easy_extinction_lw" long_name="extinction coefficient of EasyAerosol" unit="m-1" operation="instant" grid_ref="full_level_face_grid_lw_bands_monthly"/>
+   </field_group>
   </file>
 
 </file_definition>

--- a/rose-stem/app/lfric_atm/file/file_def_ancil_ral.xml
+++ b/rose-stem/app/lfric_atm/file/file_def_ancil_ral.xml
@@ -2,6 +2,7 @@
 
   <!-- Ancillary files only used by regional simulations -->
   <file id="orography_subgrid_ancil" name="orography_subgrid_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="sd_orog" name="m01s00i034" long_name="standard_deviation_of_orography" unit="1" operation="once" domain_ref="face"/>
     <field id="grad_x_orog" name="m01s00i005" long_name="orographic_gradient_X_component" unit="1" operation="once" domain_ref="face"/>
     <field id="grad_y_orog" name="m01s00i006" long_name="orographic_gradient_Y_component" unit="1" operation="once" domain_ref="face"/>
@@ -12,19 +13,26 @@
     <field id="silhouette_area_orog" name="m01s00i017" long_name="silhouette_orographic_roughness" unit="1" operation="once" domain_ref="face"/>
     <field id="horizon_angle" name="horizon_angle" long_name="horizon_angle" unit="radian" operation="once" domain_ref="face" axis_ref="horizon_angles"/>
     <field id="horizon_aspect" name="horizon_aspect" long_name="horizon_aspect" unit="radian" operation="once" domain_ref="face" axis_ref="horizon_aspects"/>
+   </field_group>
   </file>
 
   <file id="land_area_ancil" name="land_area_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="land_area_fraction" name="land_binary_mask" long_name="land_area_fraction" unit="1" operation="once" domain_ref="face"/>
+   </field_group>
   </file>
 
   <file id="hydtop_ancil" name="hydtop_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="mean_topog_index" name="m01s00i274" long_name="mean_topographic_index" unit="1" operation="once" domain_ref="face" />
     <field id="stdev_topog_index" name="m01s00i275" long_name="standard_deviation_in_topographic_index" unit="1" operation="once" domain_ref="face" />
+   </field_group>
   </file>
 
   <file id="surface_frac_ancil" name="surface_frac_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="land_tile_fraction" name="m01s00i216" long_name="fractions_of_vegetation_types" unit="1" operation="once" domain_ref="face" axis_ref="land_tiles"/>
+   </field_group>
   </file>
 
 </file_definition>

--- a/rose-stem/app/lfric_atm/file/file_def_ancil_reynolds.xml
+++ b/rose-stem/app/lfric_atm/file/file_def_ancil_reynolds.xml
@@ -2,13 +2,17 @@
 
   <!-- Ancillary files for Reynolds daily SST and sea-ice -->
   <file id="sst_ancil" name="sst_ancil" mode="read" output_freq="1d" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="sst_time" name="time" unit="days" operation="once" axis_ref="reynolds_timeseries"/>
     <field id="tstar_sea_data" name="surface_temperature" long_name="Sea surface temperature" unit="K" operation="instant" domain_ref="face" axis_ref="reynolds_timeseries"/>
+   </field_group>
   </file>
 
   <file id="sea_ice_ancil" name="sea_ice_ancil" mode="read" output_freq="1d" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="sea_ice_time" name="time" unit="hours" operation="once" axis_ref="reynolds_timeseries"/>
     <field id="sea_ice_fraction_data" name="sea_ice_area_fraction" long_name="sea_ice_fraction" unit="1" operation="instant" domain_ref="face" axis_ref="reynolds_timeseries"/>
+   </field_group>
   </file>
 
 

--- a/rose-stem/app/lfric_atm/file/file_def_ancil_surf.xml
+++ b/rose-stem/app/lfric_atm/file/file_def_ancil_surf.xml
@@ -2,14 +2,18 @@
 
   <!-- Ancillary files for Reynolds daily SST and sea-ice -->
   <file id="sst_ancil" name="sst_ancil" mode="read" output_freq="1d" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="sst_time" name="time" unit="days" operation="once" axis_ref="one_time_axis"/>
     <field id="tstar_sea_data" name="surface_temperature" long_name="Sea surface temperature" unit="K" operation="instant" domain_ref="face" axis_ref="one_time_axis" />
+   </field_group>
   </file>
 
   <file id="sea_ice_ancil" name="sea_ice_ancil" mode="read" output_freq="1d" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="sea_ice_time" name="time" unit="hours" operation="once" axis_ref="one_time_axis"/>
     <field id="sea_ice_fraction_data" name="sea_ice_area_fraction" long_name="sea_ice_fraction" unit="1" operation="instant" grid_ref="one_time_seaice_grid" />
     <field id="sea_ice_thickness_data" name="sea_ice_thickness" long_name="sea_ice_thickness" unit="m" operation="instant" grid_ref="one_time_seaice_grid"/>
+   </field_group>
   </file>
 
 </file_definition>

--- a/rose-stem/app/lfric_atm/file/file_def_lbcs.xml
+++ b/rose-stem/app/lfric_atm/file/file_def_lbcs.xml
@@ -2,6 +2,7 @@
 
   <!-- LBC files -->
   <file id="lbc" name="lbc" mode="read" output_freq="1h" convention="UGRID" cyclic="true" enabled=".FALSE.">
+   <field_group read_access=".TRUE.">
     <field id="lbc_time" name="time" unit="seconds" operation="once" axis_ref="lbc_axis" />
     <field id="lbc_theta_data" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_time_grid" operation="once" />
     <!-- <field id="lbc_rho_data" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" grid_ref="half_level_face_time_grid" operation="once"/> -->
@@ -16,6 +17,7 @@
     <!-- <field id="lbc_m_cl_data" name="m_cl" long_name="cloud_liquid_water_mixing_ratio" unit="1" grid_ref="full_level_face_time_grid" operation="once" /> -->
     <!-- <field id="lbc_m_s_data" name="m_cf" long_name="cloud_snow_mixing_ratio" unit="1" grid_ref="full_level_face_time_grid" operation="once" /> -->
     <!-- <field id="lbc_m_r_data" name="m_r" long_name="rain_mixing_ratio" unit="1" grid_ref="full_level_face_time_grid" operation="once" /> -->
+   </field_group>
   </file>
 
 </file_definition>

--- a/rose-stem/app/lfric_atm/file/iodef_gal_clim.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_gal_clim.xml
@@ -43,6 +43,7 @@
 
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<!-- Atmosphere fields -->
 	<field id="read_ew_wind_in_w3" name="ew_wind" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
 	<field id="read_ns_wind_in_w3" name="ns_wind" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
@@ -83,6 +84,7 @@
 	<field id="read_snow_layer_liq_mass" name="tile_snow_layer_liq_mass" long_name="snow_layer_liquid_mass_on_tiles" unit="kg m-2" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
 	<field id="read_snow_layer_temp" name="tile_snow_layer_temp" long_name="snow_layer_temperature_on_tiles" unit="K" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
 	<field id="read_snow_layer_rgrain" name="tile_snow_layer_rgrain" long_name="snow_layer_grain_size_on_tiles" unit="microns" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/lfric_atm/file/iodef_gal_clim_chem.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_gal_clim_chem.xml
@@ -43,6 +43,7 @@
 
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<!-- Atmosphere fields -->
 	<field id="read_ew_wind_in_w3" name="ew_wind" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
 	<field id="read_ns_wind_in_w3" name="ns_wind" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
@@ -165,6 +166,7 @@
         <field id="read_so3" name="so3" long_name="mass_fraction_of_sulphur_trioxide_in_air" unit="kg kg-1" grid_ref="full_level_face_grid" operation="once" />
         <field id="read_passive_o3" name="passive_o3" long_name="mass_fraction_of_passive_ozone_in_air" unit="kg kg-1" grid_ref="full_level_face_grid" operation="once" />
         <field id="read_age_of_air" name="age_of_air" long_name="mass_fraction_of_age_of_air_in_air" unit="kg kg-1" grid_ref="full_level_face_grid" operation="once" />
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/lfric_atm/file/iodef_gal_nwp.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_gal_nwp.xml
@@ -45,6 +45,7 @@
 
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<!-- Atmosphere fields -->
 	<field id="read_ew_wind_in_w3" name="ew_wind" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
 	<field id="read_ns_wind_in_w3" name="ns_wind" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
@@ -87,6 +88,7 @@
 	<field id="read_snow_layer_liq_mass" name="tile_snow_layer_liq_mass" long_name="snow_layer_liquid_mass_on_tiles" unit="kg m-2" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
 	<field id="read_snow_layer_temp" name="tile_snow_layer_temp" long_name="snow_layer_temperature_on_tiles" unit="K" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
 	<field id="read_snow_layer_rgrain" name="tile_snow_layer_rgrain" long_name="snow_layer_grain_size_on_tiles" unit="microns" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/lfric_atm/file/iodef_gal_nwp_coarse_aero.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_gal_nwp_coarse_aero.xml
@@ -45,6 +45,7 @@
 
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<!-- Atmosphere fields -->
 	<field id="read_ew_wind_in_w3" name="ew_wind" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
 	<field id="read_ns_wind_in_w3" name="ns_wind" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
@@ -87,6 +88,7 @@
 	<field id="read_snow_layer_liq_mass" name="tile_snow_layer_liq_mass" long_name="snow_layer_liquid_mass_on_tiles" unit="kg m-2" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
 	<field id="read_snow_layer_temp" name="tile_snow_layer_temp" long_name="snow_layer_temperature_on_tiles" unit="K" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
 	<field id="read_snow_layer_rgrain" name="tile_snow_layer_rgrain" long_name="snow_layer_grain_size_on_tiles" unit="microns" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/lfric_atm/file/iodef_gal_nwp_cycling.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_gal_nwp_cycling.xml
@@ -47,6 +47,7 @@
 
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<!-- Atmosphere fields -->
 	<field id="read_ew_wind_in_w3" name="ew_wind" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
 	<field id="read_ns_wind_in_w3" name="ns_wind" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
@@ -89,6 +90,7 @@
 	<field id="read_snow_layer_liq_mass" name="tile_snow_layer_liq_mass" long_name="snow_layer_liquid_mass_on_tiles" unit="kg m-2" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
 	<field id="read_snow_layer_temp" name="tile_snow_layer_temp" long_name="snow_layer_temperature_on_tiles" unit="K" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
 	<field id="read_snow_layer_rgrain" name="tile_snow_layer_rgrain" long_name="snow_layer_grain_size_on_tiles" unit="microns" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/lfric_atm/file/iodef_gal_nwp_hres.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_gal_nwp_hres.xml
@@ -45,6 +45,7 @@
 
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<!-- Atmosphere fields -->
 	<field id="read_ew_wind_in_w3" name="ew_wind" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
 	<field id="read_ns_wind_in_w3" name="ns_wind" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
@@ -87,6 +88,7 @@
 	<field id="read_snow_layer_liq_mass" name="tile_snow_layer_liq_mass" long_name="snow_layer_liquid_mass_on_tiles" unit="kg m-2" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
 	<field id="read_snow_layer_temp" name="tile_snow_layer_temp" long_name="snow_layer_temperature_on_tiles" unit="K" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
 	<field id="read_snow_layer_rgrain" name="tile_snow_layer_rgrain" long_name="snow_layer_grain_size_on_tiles" unit="microns" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/lfric_atm/file/iodef_idealised.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_idealised.xml
@@ -41,6 +41,7 @@
 
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<!-- Atmosphere fields -->
 	<field id="read_ew_wind_in_w3" name="ew_wind" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
 	<field id="read_ns_wind_in_w3" name="ns_wind" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
@@ -60,6 +61,7 @@
 	<!-- aquaplanet ancillary fields -->
 	<field id="read_tstar" name="tstar" long_name="surface_temperature" standard_name="surface_temperature" unit="K" domain_ref="face" operation="once" />
 	<field id="read_ozone" name="ozone" long_name="mass_fraction_of_ozone_in_air" standard_name="mass_fraction_of_ozone_in_air" unit="1" grid_ref="full_level_face_grid" operation="once" />
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/lfric_atm/file/iodef_idealised_flexchem.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_idealised_flexchem.xml
@@ -42,6 +42,7 @@
 
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<!-- Atmosphere fields -->
 	<field id="read_ew_wind_in_w3" name="ew_wind" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
 	<field id="read_ns_wind_in_w3" name="ns_wind" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
@@ -61,6 +62,7 @@
 	<!-- aquaplanet ancillary fields -->
 	<field id="read_tstar" name="tstar" long_name="surface_temperature" standard_name="surface_temperature" unit="K" domain_ref="face" operation="once" />
 	<field id="read_ozone" name="ozone" long_name="mass_fraction_of_ozone_in_air" standard_name="mass_fraction_of_ozone_in_air" unit="1" grid_ref="full_level_face_grid" operation="once" />
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/lfric_atm/file/iodef_ls_and_jedi.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_ls_and_jedi.xml
@@ -43,6 +43,7 @@
 
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <!-- Atmosphere fields -->
         <field id="read_ew_wind_in_w3" name="ew_wind" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
         <field id="read_ns_wind_in_w3" name="ns_wind" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
@@ -85,6 +86,7 @@
         <field id="read_snow_layer_liq_mass" name="tile_snow_layer_liq_mass" long_name="snow_layer_liquid_mass_on_tiles" unit="kg m-2" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
         <field id="read_snow_layer_temp" name="tile_snow_layer_temp" long_name="snow_layer_temperature_on_tiles" unit="K" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
         <field id="read_snow_layer_rgrain" name="tile_snow_layer_rgrain" long_name="snow_layer_grain_size_on_tiles" unit="microns" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/lfric_atm/file/iodef_ral.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_ral.xml
@@ -45,6 +45,7 @@
 
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<!-- Atmosphere fields -->
         <field id="read_h_wind" name="h_wind" long_name="horizontal_wind" standard_name="horizontal_wind" unit="m s-1" grid_ref="half_level_edge_grid" operation="once" />
 	<field id="read_upward_wind_in_wtheta" name="upward_wind" long_name="upward_air_velocity" standard_name="upward_air_velocity" unit="m s-1" grid_ref="full_level_face_grid" operation="once" />
@@ -86,6 +87,7 @@
 	<field id="read_snow_layer_rgrain" name="tile_snow_layer_rgrain" long_name="snow_layer_grain_size_on_tiles" unit="microns" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
         <field id="surface_altitude" name="surface_altitude" long_name="surface_altitude" unit="m" operation="once" domain_ref="face"/>
 	<field id="read_tstar_sea" name="tstar" long_name="surface_temperature" standard_name="surface_temperature" unit="K" domain_ref="face" operation="once" />
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/lfric_atm/file/iodef_ral_ls_and_jedi.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_ral_ls_and_jedi.xml
@@ -46,6 +46,7 @@
 
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<!-- Atmosphere fields -->
         <field id="read_h_wind" name="h_wind" long_name="horizontal_wind" standard_name="horizontal_wind" unit="m s-1" grid_ref="half_level_edge_grid" operation="once" />
 	<field id="read_upward_wind_in_wtheta" name="upward_wind" long_name="upward_air_velocity" standard_name="upward_air_velocity" unit="m s-1" grid_ref="full_level_face_grid" operation="once" />
@@ -87,6 +88,7 @@
 	<field id="read_snow_layer_rgrain" name="tile_snow_layer_rgrain" long_name="snow_layer_grain_size_on_tiles" unit="microns" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
         <field id="surface_altitude" name="surface_altitude" long_name="surface_altitude" unit="m" operation="once" domain_ref="face"/>
 	<field id="read_tstar_sea" name="tstar" long_name="surface_temperature" standard_name="surface_temperature" unit="K" domain_ref="face" operation="once" />
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/lfric_atm/file/iodef_test.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_test.xml
@@ -43,6 +43,7 @@
 
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<!-- Atmosphere fields -->
 	<field id="read_ew_wind_in_w3" name="ew_wind" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
 	<field id="read_ns_wind_in_w3" name="ns_wind" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
@@ -85,6 +86,7 @@
 	<field id="read_snow_layer_liq_mass" name="tile_snow_layer_liq_mass" long_name="snow_layer_liquid_mass_on_tiles" unit="kg m-2" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
 	<field id="read_snow_layer_temp" name="tile_snow_layer_temp" long_name="snow_layer_temperature_on_tiles" unit="K" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
 	<field id="read_snow_layer_rgrain" name="tile_snow_layer_rgrain" long_name="snow_layer_grain_size_on_tiles" unit="microns" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/lfric_atm/file/iodef_test1.xml
+++ b/rose-stem/app/lfric_atm/file/iodef_test1.xml
@@ -43,6 +43,7 @@
 
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<!-- Atmosphere fields -->
 	<field id="read_ew_wind_in_w3" name="ew_wind" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
 	<field id="read_ns_wind_in_w3" name="ns_wind" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
@@ -85,6 +86,7 @@
 	<field id="read_snow_layer_liq_mass" name="tile_snow_layer_liq_mass" long_name="snow_layer_liquid_mass_on_tiles" unit="kg m-2" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
 	<field id="read_snow_layer_temp" name="tile_snow_layer_temp" long_name="snow_layer_temperature_on_tiles" unit="K" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
 	<field id="read_snow_layer_rgrain" name="tile_snow_layer_rgrain" long_name="snow_layer_grain_size_on_tiles" unit="microns" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/lfric_coupled_atmosphere/file/iodef_basic_gal.xml
+++ b/rose-stem/app/lfric_coupled_atmosphere/file/iodef_basic_gal.xml
@@ -819,6 +819,7 @@
 
       <!-- File definition for checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="restart_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" operation="instant" domain_ref="checkpoint_Wtheta" />
 	<field id="restart_exner" name="exner" long_name="exner_pressure" unit="1" operation="instant" domain_ref="checkpoint_W3" />
 	<field id="restart_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" operation="instant" domain_ref="checkpoint_W3" />
@@ -829,6 +830,7 @@
 	<field id="restart_m_ci" name="m_ci" long_name="m_ci" unit="kg kg-1" operation="instant" domain_ref="checkpoint_Wtheta" />
 	<field id="restart_m_s" name="m_s" long_name="m_s" unit="kg kg-1" operation="instant" domain_ref="checkpoint_Wtheta" />
 	<field id="restart_m_g" name="m_g" long_name="m_g" unit="kg kg-1" operation="instant" domain_ref="checkpoint_Wtheta" />
+       </field_group>
       </file>
 
       <file id="lfric_diag" name="lfric_diag" output_freq="6h" convention="UGRID" enabled=".TRUE.">
@@ -924,6 +926,7 @@
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
 	<!-- aquaplanet fields -->
+       <field_group read_access=".TRUE.">
 	<field id="read_ew_wind_in_w3" name="ew_wind" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
 	<field id="read_ns_wind_in_w3" name="ns_wind" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="once" />
 	<field id="read_upward_wind_in_wtheta" name="upward_wind" long_name="upward_air_velocity" standard_name="upward_air_velocity" unit="m s-1" grid_ref="full_level_face_grid" operation="once" />
@@ -963,10 +966,12 @@
 	<field id="read_snow_layer_liq_mass" name="tile_snow_layer_liq_mass" long_name="snow_layer_liquid_mass_on_tiles" unit="kg m-2" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
 	<field id="read_snow_layer_temp" name="tile_snow_layer_temp" long_name="snow_layer_temperature_on_tiles" unit="K" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
 	<field id="read_snow_layer_rgrain" name="tile_snow_layer_rgrain" long_name="snow_layer_grain_size_on_tiles" unit="microns" domain_ref="face" operation="once" axis_ref="snow_layers_and_tiles"/>
+      </field_group>
       </file>
 
       <!-- Ancillary files to read -->
       <file id="orography_ancil" name="orography_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="surface_altitude" name="surface_altitude" long_name="surface_altitude" unit="m" operation="once" domain_ref="face"/>
 	<field id="sd_orog" name="m01s00i034" long_name="standard_deviation_of_orography" unit="1" operation="once" domain_ref="face"/>
 	<field id="grad_x_orog" name="m01s00i005" long_name="orographic_gradient_X_component" unit="1" operation="once" domain_ref="face"/>
@@ -976,44 +981,60 @@
 	<field id="grad_yy_orog" name="m01s00i037" long_name="orographic_gradient_YY_component" unit="1" operation="once" domain_ref="face"/>
 	<field id="peak_to_trough_orog" name="m01s00i018" long_name="half_of_peak_to_trough_ht_of_orog" unit="1" operation="once" domain_ref="face"/>
 	<field id="silhouette_area_orog" name="m01s00i017" long_name="silhouette_orographic_roughness" unit="1" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
       <file id="land_area_ancil" name="land_area_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="land_area_fraction" name="land_area_fraction" long_name="land_area_fraction" unit="1" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
       <file id="sea_ancil" name="sea_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="sea_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
 	<field id="chloro_sea_data" name="mass_concentration_of_chlorophyll_a_in_sea_water" long_name="Mass concentration of chlorophyll A in sea water" unit="kg m-3" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+       </field_group>
       </file>
 
       <file id="sst_ancil" name="sst_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="sst_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
 	<field id="tstar_sea_data" name="surface_temperature" long_name="Sea surface temperature" unit="K" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+       </field_group>
       </file>
 
       <file id="sea_ice_ancil" name="sea_ice_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="sea_ice_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
 	<field id="sea_ice_thickness_data" name="sea_ice_thickness" long_name="sea_ice_thickness" unit="m" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
 	<field id="sea_ice_fraction_data" name="sea_ice_area_fraction" long_name="sea_ice_fraction" unit="1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+       </field_group>
       </file>
 
       <file id="albedo_vis_ancil" name="albedo_vis_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="albedo_vis_time" name="time" unit="days" operation="once" axis_ref="monthly_climatology"/>
 	<field id="albedo_obs_vis_data" name="surface_diffuse_albedo_of_photosynthetically_active_radiation_assuming_no_snow" long_name="surface_diffuse_albedo_of_photosynthetically_active_radiation_assuming_no_snow" unit="1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+       </field_group>
       </file>
 
       <file id="albedo_nir_ancil" name="albedo_nir_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="albedo_nir_time" name="time" unit="days" operation="once" axis_ref="monthly_climatology"/>
 	<field id="albedo_obs_nir_data" name="surface_diffuse_albedo_of_near_infra_red_radiation_assuming_no_snow" long_name="surface_diffuse_albedo_of_near_infra_red_radiation_assuming_no_snow" unit="1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+       </field_group>
       </file>
 
       <file id="hydtop_ancil" name="hydtop_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="mean_topog_index" name="m01s00i274" long_name="mean_topographic_index" unit="1" operation="once" domain_ref="face" />
 	<field id="stdev_topog_index" name="m01s00i275" long_name="standard_deviation_in_topographic_index" unit="1" operation="once" domain_ref="face" />
+       </field_group>
       </file>
 
       <file id="soil_ancil" name="soil_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="soil_albedo" name="soil_albedo" long_name="soil_albedo" unit="1" operation="once" domain_ref="face"/>
 	<field id="soil_thermal_cond" name="soil_thermal_conductivity" long_name="soil_thermal_conductivity" unit="Wm-1K-1" operation="once" domain_ref="face"/>
 	<field id="soil_moist_wilt" name="volume_fraction_of_condensed_water_in_soil_at_wilting_point" long_name="soil_moisture_at_wilting_point" unit="m3 m-3" operation="once" domain_ref="face" />
@@ -1023,26 +1044,34 @@
 	<field id="soil_thermal_cap" name="soil_thermal_capacity" long_name="soil_thermal_capacity" unit="J K-1 m-3" operation="once" domain_ref="face" />
 	<field id="soil_suction_sat" name="soil_suction_at_saturation" long_name="soil_suction_at_saturation" unit="1" operation="once" domain_ref="face" />
 	<field id="clapp_horn_b" name="m01s00i207" long_name="exponent_for_soil_moisture_functions" unit="1" operation="once" domain_ref="face" />
+       </field_group>
       </file>
 
       <file id="surface_frac_ancil" name="surface_frac_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="land_tile_fraction" name="m01s00i216" long_name="fractions_of_vegetation_types" unit="1" operation="once" domain_ref="face" axis_ref="land_tiles"/>
+       </field_group>
       </file>
 
       <file id="plant_func_ancil" name="plant_func_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="plant_func_time" name="month_number" unit="months" operation="once" axis_ref="monthly_climatology"/>
 	<field id="canopy_height_data" name="canopy_height" long_name="canopy_height" unit="1" operation="once" grid_ref="pft_monthly_grid"/>
 	<field id="leaf_area_index_data" name="leaf_area_index" long_name="leaf_area_index" unit="1" operation="once" grid_ref="pft_monthly_grid"/>
+       </field_group>
       </file>
 
       <file id="ozone_ancil" name="ozone_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="ozone_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
 	<field id="ozone_data" name="mass_fraction_of_ozone_in_air" long_name="mass_fraction_of_ozone_in_air" unit="1" operation="instant" grid_ref="variable_3D_monthly_grid"/>
+       </field_group>
       </file>
 
       <!-- The following dust fields will need adding here when available in the ancillary file: acc_sol_du, cor_sol_du, n_acc_ins, acc_ins_du, n_cor_ins, cor_ins_du -->
       <!-- Note that variable names have changed in code and will need to changed in the ancillary file in future,  e.g. OC to OM-->
       <file id="aerosols_ancil" name="aerosols_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <field id="aerosols_time" name="time" unit="days" operation="once" axis_ref="monthly_climatology"/>
         <field id="n_ait_sol_data" name="AiSo___103" long_name="aitken_soluble_mode_number" unit="1" operation="once" grid_ref="variable_3D_monthly_grid"/>
         <field id="ait_sol_su_data" name="AiSoSU_104" long_name="aitken_soluble_mode_h2so4_mmr" unit="kg kg-1" operation="once" grid_ref="variable_3D_monthly_grid"/>
@@ -1061,98 +1090,135 @@
         <field id="n_ait_ins_data" name="AiIn___119" long_name="aitken_insoluble_mode_number" unit="1" operation="once" grid_ref="variable_3D_monthly_grid"/>
         <field id="ait_ins_bc_data" name="AiInBC_120" long_name="aitken_insoluble_mode_black_carbon_mmr" unit="kg kg-1" operation="once" grid_ref="variable_3D_monthly_grid"/>
         <field id="ait_ins_om_data" name="AiInOC_121" long_name="aitken_insoluble_mode_organic_matter_mmr" unit="kg kg-1" operation="once" grid_ref="variable_3D_monthly_grid"/>
+       </field_group>
       </file>
 
     <!-- UKCA emission files -->
       <file id="emiss_bc_biofuel_ancil" name="emiss_bc_biofuel_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="em_bc_bf_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
        <field id="emiss_bc_biofuel_data" name="emissions_BC_biofuel" long_name="BC biofuel surf emissions" unit="kg m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+       </field_group>
        </file>
 
       <file id="emiss_bc_fossil_ancil" name="emiss_bc_fossil_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="em_bc_ff_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
        <field id="emiss_bc_fossil_data" name="emissions_BC_fossil" long_name="BC fossil fuel surf emissions" unit="kg m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+       </field_group>
        </file>
 
       <file id="emiss_bc_biomass_ancil" name="emiss_bc_biomass_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="em_bc_bb_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
        <field id="emiss_bc_biomass_data" name="emissions_BC_biomass" long_name="BC biomass 3D emissions" unit="kg m-2 s-1" operation="instant" grid_ref="3D_monthly_grid"/>
+       </field_group>
        </file>
 
       <file id="emiss_dms_land_ancil" name="emiss_dms_land_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="em_dms_lnd_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
        <field id="emiss_dms_land_data" name="emissions_DMS" long_name="DMS emissions expressed as sulfur" unit="kg(S) m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+       </field_group>
        </file>
 
       <file id="dms_conc_ocean_ancil" name="dms_conc_ocean_ancil"  mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="dms_ocn_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
        <field id="dms_conc_ocean_data" name="mole_concentration_of_dimethyl_sulfide_in_sea_water" long_name="mole_concentration_of_dimethyl_sulfide_in_sea_water" unit="nmoles l-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+       </field_group>
        </file>
 
       <file id="emiss_monoterp_ancil" name="emiss_monoterp_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="em_mterp_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
        <field id="emiss_monoterp_data" name="emissions_Monoterp" long_name="Monoterpene surf emissions expressed as carbon" unit="kg(C) m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+       </field_group>
        </file>
 
       <file id="emiss_om_biofuel_ancil" name="emiss_om_biofuel_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="em_om_bf_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
        <field id="emiss_om_biofuel_data" name="emissions_OC_biofuel" long_name="OC biofuel surf emissions expressed as carbon" unit="kg(C) m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+       </field_group>
        </file>
 
       <file id="emiss_om_fossil_ancil" name="emiss_om_fossil_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="em_om_ff_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
        <field id="emiss_om_fossil_data" name="emissions_OC_fossil" long_name="OC fossil fuel surf emissions expressed as carbon" unit="kg(C) m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+       </field_group>
        </file>
 
       <file id="emiss_om_biomass_ancil" name="emiss_om_biomass_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="em_om_bb_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
        <field id="emiss_om_biomass_data" name="emissions_OC_biomass" long_name="OC biomass 3D emissions expressed as carbon" unit="kg(C) m-2 s-1" operation="instant" grid_ref="3D_monthly_grid"/>
+       </field_group>
        </file>
 
       <file id="emiss_so2_low_ancil" name="emiss_so2_low_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="em_so2_lo_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
        <field id="emiss_so2_low_data" name="emissions_SO2_low" long_name="SO2 low level emissions expressed as sulfur" unit="kg(S) m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+       </field_group>
        </file>
 
       <file id="emiss_so2_high_ancil" name="emiss_so2_high_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="em_so2_hi_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
        <field id="emiss_so2_high_data" name="emissions_SO2_high" long_name="SO2 high level emissions expressed as sulfur" unit="kg(S) m-2 s-1" operation="instant" domain_ref="face" axis_ref="monthly_climatology"/>
+       </field_group>
        </file>
 
       <file id="emiss_so2_nat_ancil" name="emiss_so2_nat_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="emiss_so2_nat" name="emissions_SO2_nat" long_name="SO2 natural emissions expressed as sulfur" unit="kg(S) m-2 s-1" operation="once" grid_ref="full_level_face_grid"/>
+       </field_group>
        </file>
 
       <file id="soil_dust_ancil" name="soil_dust_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="false" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="soil_clay" name="volume_fraction_of_clay_in_soil" long_name="volume_fraction_of_clay_in_soil" unit="m3 m-3" operation="once" domain_ref="face"/>
        <field id="soil_sand" name="volume_fraction_of_sand_in_soil" long_name="volume_fraction_of_sand_in_soil" unit="m3 m-3" operation="once" domain_ref="face"/>
        <field id="dust_mrel" name="mass_fraction_of_dust_in_size_bins" long_name="mass_fraction_of_dust_in_size_bins" unit="kg kg-1" operation="once" domain_ref="face" axis_ref="dust_divisions" />
+       </field_group>
       </file>
 
       <!--- UKCA Offline Oxidant ancils -->
       <file id="h2o2_limit_ancil" name="h2o2_limit_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="h2o2_limit_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
        <field id="h2o2_limit_data" name="H2O2" long_name="H2O2 mass mixing ratio" unit="1" operation="instant" grid_ref="3D_monthly_grid"/>
+       </field_group>
        </file>
 
       <file id="ho2_ancil" name="ho2_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="ho2_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
        <field id="ho2_data" name="HO2" long_name="HO2 mass mixing ratio" unit="1" operation="instant" grid_ref="3D_monthly_grid"/>
+       </field_group>
        </file>
 
       <file id="no3_ancil" name="no3_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="no3_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
        <field id="no3_data" name="NO3" long_name="NO3 mass mixing ratio" unit="1" operation="instant" grid_ref="3D_monthly_grid"/>
+       </field_group>
        </file>
 
       <file id="o3_ancil" name="o3_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="o3_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
        <field id="o3_data" name="O3" long_name="O3 mass mixing ratio" unit="1" operation="instant" grid_ref="3D_monthly_grid"/>
+       </field_group>
        </file>
 
       <file id="oh_ancil" name="oh_ancil" mode="read" output_freq="1mo" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="oh_time" name="time" unit="hours" operation="once" axis_ref="monthly_climatology"/>
        <field id="oh_data" name="OH" long_name="OH mass mixing ratio" unit="1" operation="instant" grid_ref="3D_monthly_grid"/>
+       </field_group>
        </file>
 
     </file_definition>

--- a/rose-stem/app/name_transport/file/iodef.xml
+++ b/rose-stem/app/name_transport/file/iodef.xml
@@ -75,10 +75,12 @@
 
        <!-- file definition for checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint" mode="read" output_freq="1ts" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="restart_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_tracer_con" name="tracer_con" long_name="tracer_con" standard_name="tracer_con" unit="kg/kg" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_u" name="u" long_name="wind" unit="m s-1" operation="instant" domain_ref="checkpoint_W2" />
-      </file>
+       </field_group>
+     </file>
 
       <file id="lfric_diag" name="lfric_diag" output_freq="1ts" convention="UGRID" enabled=".TRUE.">
         <field field_ref="u_in_w2h"/>

--- a/rose-stem/app/scintelapi/file/iodef.xml
+++ b/rose-stem/app/scintelapi/file/iodef.xml
@@ -57,6 +57,7 @@
 
       <!-- File definition for lfric checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="read_ew_wind_in_w3" name="ew_wind_in_w3" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_ns_wind_in_w3" name="ns_wind_in_w3" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_theta_in_wtheta" name="theta_in_wtheta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" operation="instant" />
@@ -67,17 +68,22 @@
        <field id="read_mcl_in_wtheta" name="mcl_in_wtheta" long_name="cloud_liquid_water_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_mcf_in_wtheta" name="mcf_in_wtheta" long_name="cloud_ice_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_tstar" name="tstar" long_name="surface_temperature" standard_name="surface_temperature" unit="K" domain_ref="face" operation="instant" />
+       </field_group>
       </file>
 
       <!-- File definition for land area fraction read -->
       <file id="land_area_ancil" name="land_area_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <field id="read_land_area_fraction" name="land_area_fraction" long_name="land_area_fraction" unit="1" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
        <!-- File definition for soil_param_ancil read -->
       <file id="soil_param_ancil" name="soil_param_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <field id="read_vol_frac_con_water_wilt_point" name="volume_fraction_of_condensed_water_in_soil_at_wilting_point" long_name="volume_fraction_of_condensed_water_in_soil_at_wilting_point" unit="1" operation="once" domain_ref="face"/>
         <field id="read_vol_frac_con_water_crit_point" name="volume_fraction_of_condensed_water_in_soil_at_critical_point" long_name="volume_fraction_of_condensed_water_in_soil_at_critical_point" unit="1" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/scintelapi/file/iodef_basic.xml
+++ b/rose-stem/app/scintelapi/file/iodef_basic.xml
@@ -58,6 +58,7 @@
 
       <!-- File definition for lfric checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="read_ew_wind_in_w3" name="ew_wind_in_w3" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_ns_wind_in_w3" name="ns_wind_in_w3" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_theta_in_wtheta" name="theta_in_wtheta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" operation="instant" />
@@ -68,17 +69,22 @@
        <field id="read_mcl_in_wtheta" name="mcl_in_wtheta" long_name="cloud_liquid_water_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_mcf_in_wtheta" name="mcf_in_wtheta" long_name="cloud_ice_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_tstar" name="tstar" long_name="surface_temperature" standard_name="surface_temperature" unit="K" domain_ref="face" operation="instant" />
-      </file>
+       </field_group>
+     </file>
 
       <!-- File definition for land area fraction read -->
       <file id="land_area_ancil" name="land_area_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <field id="read_land_area_fraction" name="land_area_fraction" long_name="land_area_fraction" unit="1" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
        <!-- File definition for soil_param_ancil read -->
       <file id="soil_param_ancil" name="soil_param_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
         <field id="read_vol_frac_con_water_wilt_point" name="volume_fraction_of_condensed_water_in_soil_at_wilting_point" long_name="volume_fraction_of_condensed_water_in_soil_at_wilting_point" unit="1" operation="once" domain_ref="face"/>
         <field id="read_vol_frac_con_water_crit_point" name="volume_fraction_of_condensed_water_in_soil_at_critical_point" long_name="volume_fraction_of_condensed_water_in_soil_at_critical_point" unit="1" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/scintelapi/file/iodef_mixingratio.xml
+++ b/rose-stem/app/scintelapi/file/iodef_mixingratio.xml
@@ -47,6 +47,7 @@
 
       <!-- File definition for lfric checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="read_rho" name="rho" long_name="air_density" unit="1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_m_v" name="m_v" long_name="humidity_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_m_cl" name="m_cl" long_name="cloud_liquid_water_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
@@ -57,7 +58,8 @@
        <field id="read_qcl" name="qcl" long_name="specific_humidity_cloud_liquid"  unit="1" grid_ref="full_level_face_grid" operation="instant"/>
        <field id="read_qcf" name="qcf" long_name="specific_humidity_cloud_ice"  unit="1" grid_ref="full_level_face_grid" operation="instant"/>
        <field id="read_qrain" name="qrain" long_name="mass_fraction_of_rain_in_air" unit="1" grid_ref="full_level_face_grid" operation="instant"/>
-      </file>
+       </field_group>
+     </file>
 
     </file_definition>
 

--- a/rose-stem/app/shallow_water/file/iodef.xml
+++ b/rose-stem/app/shallow_water/file/iodef.xml
@@ -112,6 +112,7 @@
 
        <!-- file definition for checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_swe_checkpoint" mode="read" output_freq="1ts" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="restart_geopot" name="geopot" long_name="fluid_geopotential" standard_name="geopotential" unit="m2 s-2" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_buoyancy" name="buoyancy" long_name="buoyancy" unit="kg m s-2" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_wind" name="wind" long_name="wind" unit="m s-1" operation="instant" domain_ref="checkpoint_W2" />
@@ -119,7 +120,8 @@
        <field id="restart_tracer_const" name="tracer_const" long_name="tracer constant" unit="kg kg-1" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_tracer_pv" name="tracer_pv" long_name="tracer potential vorticity" unit="kg kg-1" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_tracer_step" name="tracer_step" long_name="tracer step function" unit="kg kg-1" operation="instant" domain_ref="checkpoint_W3" />
-      </file>
+       </field_group>
+     </file>
 
       <file id="lfric_diag" name="lfric_swe_diag" output_freq="10ts" convention="UGRID" enabled=".TRUE.">
         <field field_ref="wind1"/>

--- a/rose-stem/app/transport/file/iodef.xml
+++ b/rose-stem/app/transport/file/iodef.xml
@@ -122,6 +122,7 @@
 
        <!-- file definition for checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint" mode="read" output_freq="1ts" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="restart_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_tracer_con" name="tracer_con" long_name="tracer_con" standard_name="tracer_con" unit="kg/kg" operation="instant" domain_ref="checkpoint_W3" />
@@ -134,7 +135,8 @@
        <field id="restart_wt_aerosol" name="wt_aerosol" long_name="wt_aerosol" standard_name="wt_aerosol" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_w3_aerosol" name="w3_aerosol" long_name="w3_aerosol" standard_name="w3_aerosol" unit="kg/kg" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_aerosol_wind" name="aerosol_wind" long_name="aerosol_wind" unit="m s-1" operation="instant" domain_ref="checkpoint_W2" />
-      </file>
+       </field_group>
+     </file>
 
       <file id="lfric_diag" name="lfric_diag" output_freq="1ts" convention="UGRID" enabled=".TRUE.">
         <field field_ref="u_in_w2h"/>

--- a/rose-stem/app/transport/file/iodef_coarse_aero.xml
+++ b/rose-stem/app/transport/file/iodef_coarse_aero.xml
@@ -138,6 +138,7 @@
 
        <!-- file definition for checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint" mode="read" output_freq="1ts" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="restart_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_tracer_con" name="tracer_con" long_name="tracer_con" standard_name="tracer_con" unit="kg/kg" operation="instant" domain_ref="checkpoint_W3" />
@@ -150,7 +151,8 @@
        <field id="restart_wt_aerosol" name="wt_aerosol" long_name="wt_aerosol" standard_name="wt_aerosol" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_w3_aerosol" name="w3_aerosol" long_name="w3_aerosol" standard_name="w3_aerosol" unit="kg/kg" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_aerosol_wind" name="aerosol_wind" long_name="aerosol_wind" unit="m s-1" operation="instant" domain_ref="checkpoint_W2" />
-      </file>
+       </field_group>
+     </file>
 
       <file id="lfric_diag" name="lfric_diag" output_freq="1ts" convention="UGRID" enabled=".TRUE.">
         <field field_ref="u_in_w2h"/>

--- a/rose-stem/app/um2lfric/file/iodef_basicgal_stash_list.xml
+++ b/rose-stem/app/um2lfric/file/iodef_basicgal_stash_list.xml
@@ -153,7 +153,9 @@
       </file>
 
       <file id="land_area_ancil" name="land_area_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="land_area_fraction" name="land_area_fraction" long_name="land_area_fraction" unit="1" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/um2lfric/file/iodef_falklands_lam_stash_list.xml
+++ b/rose-stem/app/um2lfric/file/iodef_falklands_lam_stash_list.xml
@@ -160,7 +160,9 @@
       </file>
 
       <file id="land_area_ancil" name="land_area_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="land_area_fraction" name="land_area_fraction" long_name="land_area_fraction" unit="1" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/um2lfric/file/iodef_nwp_gal9_stash_list.xml
+++ b/rose-stem/app/um2lfric/file/iodef_nwp_gal9_stash_list.xml
@@ -165,7 +165,9 @@
       </file>
 
       <file id="land_area_ancil" name="land_area_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="land_area_fraction" name="land_area_fraction" long_name="land_area_fraction" unit="1" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/um2lfric/file/iodef_protogal_chem_stash_list.xml
+++ b/rose-stem/app/um2lfric/file/iodef_protogal_chem_stash_list.xml
@@ -421,7 +421,9 @@
       </file>
 
       <file id="land_area_ancil" name="land_area_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="land_area_fraction" name="land_area_fraction" long_name="land_area_fraction" unit="1" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/app/um2lfric/file/iodef_protogal_stash_list.xml
+++ b/rose-stem/app/um2lfric/file/iodef_protogal_stash_list.xml
@@ -193,7 +193,9 @@
       </file>
 
       <file id="land_area_ancil" name="land_area_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
 	<field id="land_area_fraction" name="land_area_fraction" long_name="land_area_fraction" unit="1" operation="once" domain_ref="face"/>
+       </field_group>
       </file>
 
     </file_definition>

--- a/rose-stem/site/meto/lfric_atm/tasks_lfric_atm_ex1a.cylc
+++ b/rose-stem/site/meto/lfric_atm/tasks_lfric_atm_ex1a.cylc
@@ -19,13 +19,13 @@
 {% elif task_ns.conf_name == "nwp_gal9_coarse_aero_threaded-C48_MG" %}
 
     {% do task_dict.update({
-        "memory": [24, "GB"],
+        "memory": [36, "GB"],
     }) %}
 
 {% elif task_ns.conf_name == "nwp_gal9_debug-C48_MG" %}
 
     {% do task_dict.update({
-        "memory": [36, "GB"],
+        "memory": [48, "GB"],
     }) %}
 
 {% elif task_ns.conf_name == "clim_gal9-C12" %}

--- a/science/linear/integration-test/runge_kutta/iodef.xml
+++ b/science/linear/integration-test/runge_kutta/iodef.xml
@@ -155,6 +155,7 @@
 
        <!-- file definition for checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="restart_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_exner" name="exner" long_name="exner_pressure" unit="1" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" operation="instant" domain_ref="checkpoint_W3" />
@@ -165,6 +166,7 @@
        <field id="restart_m_ci" name="m_ci" long_name="m_ci" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_m_s" name="m_s" long_name="m_s" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_m_g" name="m_g" long_name="m_g" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
+       </field_group>
        </file>
 
       <file id="lfric_diag" name="lfric_diag" output_freq="6h" convention="UGRID" enabled=".TRUE.">
@@ -236,6 +238,7 @@
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
 
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="read_ew_wind_in_w3" name="ew_wind_in_w3" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_ns_wind_in_w3" name="ns_wind_in_w3" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_theta_in_wtheta" name="theta_in_wtheta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" operation="instant" />
@@ -246,13 +249,16 @@
        <field id="read_mcl_in_wtheta" name="mcl_in_wtheta" long_name="cloud_liquid_water_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_mcf_in_wtheta" name="mcf_in_wtheta" long_name="cloud_ice_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_tstar" name="tstar" long_name="surface_temperature" standard_name="surface_temperature" unit="K" domain_ref="face" operation="instant" />
+       </field_group>
       </file>
 
         <!-- ANCIL FILES -->
 
       <file id="orography_mean_ancil" name="orography_mean_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="surface_altitude" name="surface_altitude" long_name="Surface altitude" unit="m" operation="once" domain_ref="face"/>
-       </file>
+       </field_group>
+      </file>
 
     </file_definition>
 

--- a/science/linear/integration-test/semi_implicit/iodef.xml
+++ b/science/linear/integration-test/semi_implicit/iodef.xml
@@ -154,6 +154,7 @@
 
        <!-- file definition for checkpoint read -->
       <file id="lfric_checkpoint_read" name="lfric_checkpoint_read" mode="read" output_freq="1ts" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="restart_theta" name="theta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_exner" name="exner" long_name="exner_pressure" unit="1" operation="instant" domain_ref="checkpoint_W3" />
        <field id="restart_rho" name="rho" long_name="air_density" standard_name="air_density" unit="kg m-3" operation="instant" domain_ref="checkpoint_W3" />
@@ -164,6 +165,7 @@
        <field id="restart_m_ci" name="m_ci" long_name="m_ci" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_m_s" name="m_s" long_name="m_s" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
        <field id="restart_m_g" name="m_g" long_name="m_g" unit="kg/kg" operation="instant" domain_ref="checkpoint_Wtheta" />
+       </field_group>
        </file>
 
       <file id="lfric_diag" name="lfric_diag" output_freq="6h" convention="UGRID" enabled=".TRUE.">
@@ -235,6 +237,7 @@
       <!-- File definition for reading in from a UM2LFRic FD UGRID format dump  -->
 
       <file id="read_lfric_fd_dump" name="lfric_fd_dump" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="read_ew_wind_in_w3" name="ew_wind_in_w3" long_name="eastward_wind" standard_name="eastward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_ns_wind_in_w3" name="ns_wind_in_w3" long_name="northward_wind" standard_name="northward_wind" unit="m s-1" grid_ref="half_level_face_grid" operation="instant" />
        <field id="read_theta_in_wtheta" name="theta_in_wtheta" long_name="air_potential_temperature" standard_name="air_potential_temperature" unit="K" grid_ref="full_level_face_grid" operation="instant" />
@@ -245,13 +248,16 @@
        <field id="read_mcl_in_wtheta" name="mcl_in_wtheta" long_name="cloud_liquid_water_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_mcf_in_wtheta" name="mcf_in_wtheta" long_name="cloud_ice_mixing_ratio"  unit="1" grid_ref="full_level_face_grid" operation="instant" />
        <field id="read_tstar" name="tstar" long_name="surface_temperature" standard_name="surface_temperature" unit="K" domain_ref="face" operation="instant" />
+       </field_group>
       </file>
 
         <!-- ANCIL FILES -->
 
       <file id="orography_mean_ancil" name="orography_mean_ancil" mode="read" output_freq="1ts" convention="UGRID" cyclic="true" enabled=".FALSE.">
+       <field_group read_access=".TRUE.">
        <field id="surface_altitude" name="surface_altitude" long_name="Surface altitude" unit="m" operation="once" domain_ref="face"/>
-       </file>
+       </field_group>
+      </file>
 
     </file_definition>
 


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: <!-- SR id, filled by author when ready for review (e.g. @octocat) -->
Code Reviewer: @svadams 

Blocked: Memory performance, correct scoping and XML configuration approach under question.

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

This change introduces XIOS good practice to the definition of fields to be read within XIOS XML config files.

Specifically, the use of `read_access=".TRUE."` is recommended for all fields being read.

This is implemented in `lfric_apps` in different ways, some changes have already been applied to `lfric_core` to facilitate this, but many XML files are read directly and used by XIOS client programmes, such as `lfric_atm`

whilst good practice for using XIOS2, the use of `read_access=".TRUE."` is mandatory for future adoption of XIOS3.
This change is supposed to be fully backwards compatible, but there are problems with a small number of changes, reverted in cca3a53cc166e4f6de6244ebb9d0122562048cba

this should be understood and documented prior to adoption of this change.

If it is fully backwards compatible, then this can be adopted for XIOS2 use and make evaluation and testing of XIOS3 easier.

Note also that there is a change to the memory overhead for a small number of lfric_atm jobs that run in attached mode, on the shared queue on EX1A:
```
s/24GB/36GB  run_lfric_atm_nwp_gal9_coarse_aero_threaded-C48_MG_ex1a_cce_production-32bit
s/24GB/36GB  run_lfric_atm_nwp_gal9_coarse_aero_threaded-C48_MG_ex1a_cce_fast_debug-32bit
s/24GB/36GB  run_lfric_atm_nwp_gal9_coarse_aero_threaded-C48_MG_ex1a_gnu_fast-debug-32bit
s/36GB/36GB  run_lfric_atm_nwp_gal9_debug-C48_MG_ex1a_cce_full-debug-32bit
```

see 116d32f379713868bc1f009d1718a5b865946f03
this change commit also requires more justification.

## Linked PRs
- linked [lfric-jedi](https://github.com/JCSDA-internal/lfric-jedi/pull/1236)

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] I have tested this change locally, using the LFRic Apps rose-stem suite
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

# Test Suite Results - lfric_apps - readAccessXML/run3

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [readAccessXML/run3](https://cylchub/services/cylc-review/cycles/mark.hedley/?suite=readAccessXML%2Frun3) |
| Suite User | mark.hedley |
| Workflow Start | 2026-03-05T13:33:40 |
| Groups Run | all |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| casim | [MetOffice/casim@2026.03.1](https://github.com/MetOffice/casim/tree/2026.03.1) | True |
| jules | [MetOffice/jules@2026.03.1](https://github.com/MetOffice/jules/tree/2026.03.1) | True |
| lfric_apps | [mo-marqh/lfric_apps@readAccessXML](https://github.com/mo-marqh/lfric_apps/tree/readAccessXML) | False |
| lfric_core | [MetOffice/lfric_core@2026.03.1](https://github.com/MetOffice/lfric_core/tree/2026.03.1) | True |
| moci | [MetOffice/moci@2026.03.1](https://github.com/MetOffice/moci/tree/2026.03.1) | True |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@2026.03.1](https://github.com/MetOffice/SimSys_Scripts/tree/2026.03.1) | True |
| socrates | [MetOffice/socrates@2026.03.1](https://github.com/MetOffice/socrates/tree/2026.03.1) | True |
| socrates-spectral | [MetOffice/socrates-spectral@2026.03.1](https://github.com/MetOffice/socrates-spectral/tree/2026.03.1) | True |
| ukca | [MetOffice/ukca@2026.03.1](https://github.com/MetOffice/ukca/tree/2026.03.1) | True |

## Task Information
:white_check_mark: succeeded tasks - 1511


## Security Considerations

- [ ] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
