### PR TITLE
revert mistaken merge in tasks_lfric_atm.cylc

### DIFF
--- a/rose-stem/site/common/lfric_atm/tasks_lfric_atm.cylc
+++ b/rose-stem/site/common/lfric_atm/tasks_lfric_atm.cylc
@@ -258,20 +258,6 @@
         "mpi_parts_xios" : 16,
     }) %}
 
-{% elif task_ns.conf_name == "nwp_gal9-C896_MG" %}
-
-    {% do task_dict.update({
-        "opt_confs": ["um_dump"],
-        "resolution": "C896_MG",
-        "DT": 240,
-        "tsteps": 120,
-        "mpi_parts": 4704,
-        "xios_nodes": 4,
-        "mpi_parts_xios" : 32,
-        "log_level": "info",
-        "plot_str": "plot_map.py $NODAL_DATA_DIR/lfric_diagnostics.nc  $PLOT_DIR",
-    }) %}
-
 {% elif task_ns.conf_name == "nwp_gal9_coarse_aero-C48_MG" %}
 
     {% do task_dict.update({


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: @iboutle 
Code Reviewer: <!-- CR id, filled by SSD/CCD (e.g. @octocat) --> @Pierre-siddall 

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

The merged change #214  altered the setup of the `lfric_atm` task dict, but part of that change was reverted by #163

this looks like a merge error, a chunk of code was added, and a chunk of code removed by #214 next door was re-inserted.
perhaps a conflict resolution error?

this change restores the configuration of C896 tests to the state as mandated by #214 

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] I have tested this change locally, using the LFRic Apps rose-stem suite
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

# Test Suite Results - lfric_apps - fix_lfric_atm_tasks/run1

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [fix_lfric_atm_tasks/run1](https://cylchub/services/cylc-review/cycles/pierre.siddall/?suite=fix_lfric_atm_tasks%2Frun1) |
| Suite User | pierre.siddall |
| Workflow Start | 2026-04-08T09:43:20 |
| Groups Run | developer |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| casim | [MetOffice/casim@2026.03.2](https://github.com/MetOffice/casim/tree/2026.03.2) | True |
| jules | [MetOffice/jules@2026.03.2](https://github.com/MetOffice/jules/tree/2026.03.2) | True |
| lfric_apps | [Pierre-siddall/lfric_apps@fixmergeConflict_lfric_atm_tasks](https://github.com/Pierre-siddall/lfric_apps/tree/fixmergeConflict_lfric_atm_tasks) | False |
| lfric_core | [MetOffice/lfric_core@018e40c](https://github.com/MetOffice/lfric_core/tree/018e40c) | True |
| moci | [MetOffice/moci@2026.03.2](https://github.com/MetOffice/moci/tree/2026.03.2) | True |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@4387949](https://github.com/MetOffice/SimSys_Scripts/tree/4387949) | True |
| socrates | [MetOffice/socrates@2026.03.2](https://github.com/MetOffice/socrates/tree/2026.03.2) | True |
| socrates-spectral | [MetOffice/socrates-spectral@2026.03.2](https://github.com/MetOffice/socrates-spectral/tree/2026.03.2) | True |
| ukca | [MetOffice/ukca@2026.03.2](https://github.com/MetOffice/ukca/tree/2026.03.2) | True |

## Task Information
:white_check_mark: succeeded tasks - 1165


<!-- Paste your trac.log from testing output here -->

## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [x] Sensitive data is properly handled (if applicable)
- [x] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [x] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [x] I understand this area of code and the changes being added
- [x] The proposed changes correspond to the pull request description
- [x] Documentation is sufficient (do documentation papers need updating)
- [x] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [x] All dependencies have been resolved
- [x] Related Issues have been properly linked and addressed
- [x] CLA compliance has been confirmed
- [x] Code quality standards have been met
- [x] Tests are adequate and have passed
- [x] Documentation is complete and accurate
- [x] Security considerations have been addressed
- [x] Performance impact is acceptable
