### PR TITLE
Use all allocated CPUs for building applications

### DIFF
--- a/rose-stem/templates/runtime/generate_runtime_build.cylc
+++ b/rose-stem/templates/runtime/generate_runtime_build.cylc
@@ -53,7 +53,7 @@
             PSYCLONE_TRANSFORMATION = {{psyclone_transformation}}
             UM_FCM_TARGET_PLATFORM  = {{SITE}}-{{task_ns.platform}}
             LFRIC_TARGET_PLATFORM   = {{SITE}}-{{task_ns.platform}}
-            MAKE_THREADS            = 6
+            MAKE_THREADS            = {{task_values["build_cpus"]}}
             RDEF_PRECISION          = {{task_values["precision"]["rdef"]}}
             R_TRAN_PRECISION        = {{task_values["precision"]["rtran"]}}
             R_BL_PRECISION          = {{task_values["precision"]["rbl"]}}


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: 
Code Reviewer: @james-bruten-mo 

<!-- To be completed by the developer -->

This PR addresses the issue described in #447 - a hard-coded number of make threads (`-j`) tht is limiting speed of builds.

By using the number of allocated CPUs as the number of make threads, the average build time is decreased. This is most notable for builds on the EX machines which allocate 24 cpus but have only used 6.

Here is a sample of build times (mins:secs) pre- and post-changes in this PR:

| Application                           | build time pre-change | build time post-change |
| ------------------------------------- | --------------------- | ---------------------- |
| build_gungho_model_ex1a_gnu_fast-debug-64bit | 05:10 | 03:56 |
| build_lfric_atm_ex1a_cce_fast-debug-64bit | 27:52 | 19:13 |
| build_ngarch_ex1a_gnu_fast-debug-64bit | 11:52 | 09:00 |
| build_ngarch_ex1a_gnu_full-debug-64bit | 10:40 | 08:03 |
| build_lfric2lfric_ex1a_cce_fast-debug-64bit | 08:27 | 07:18 |

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #447 (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] I have tested this change locally, using the LFRic Apps rose-stem suite
- [x] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [x] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [x] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

## trac.log
### Test Suite Results - lfric_apps - lfric_apps/run8

#### Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [lfric_apps/run8](https://cylchub/services/cylc-review/cycles/oakley.brunt/?suite=lfric_apps%2Frun8) |
| Suite User | oakley.brunt |
| Workflow Start | 2026-04-22T09:30:56 |
| Groups Run | developer |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| casim | [MetOffice/casim@2026.03.2](https://github.com/MetOffice/casim/tree/2026.03.2) | True |
| jules | [MetOffice/jules@2026.03.2](https://github.com/MetOffice/jules/tree/2026.03.2) | True |
| lfric_apps | [oakleybrunt/LFRicApps@timing-threads](https://github.com/oakleybrunt/LFRicApps/tree/timing-threads) | False |
| lfric_core | [MetOffice/lfric_core@a963e38](https://github.com/MetOffice/lfric_core/tree/a963e38) | True |
| moci | [MetOffice/moci@2026.03.2](https://github.com/MetOffice/moci/tree/2026.03.2) | True |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@4387949](https://github.com/MetOffice/SimSys_Scripts/tree/4387949) | True |
| socrates | [MetOffice/socrates@2026.03.2](https://github.com/MetOffice/socrates/tree/2026.03.2) | True |
| socrates-spectral | [MetOffice/socrates-spectral@2026.03.2](https://github.com/MetOffice/socrates-spectral/tree/2026.03.2) | True |
| ukca | [MetOffice/ukca@2026.03.2](https://github.com/MetOffice/ukca/tree/2026.03.2) | True |

#### Task Information
:white_check_mark: succeeded tasks - 1185

<!-- Paste your trac.log from testing output here -->

## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [x] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
