### PR TITLE
Fix shared fortitude

### DIFF
--- a/rose-stem/app/check_fortitude_linter/file/fortitude.toml
+++ b/rose-stem/app/check_fortitude_linter/file/fortitude.toml
@@ -6,16 +6,16 @@
 
 [check]
 
-file-extensions= ["f90", "F90", "X90", "x90", "pf"]   #check these file types
+file-extensions= ["f90", "F90", "X90", "x90"]   #check these file types
 
-select = ["E000", "C001", "C021", "C022", "C031", "C032", "C043",
+select = ["E000", "E001", "C001", "C021", "C022", "C031", "C032", "C043",
 "C051", "C061", "C071", "C072", "C081", "C091", "C082", "C092", "C121",
 "C132", "C141", "OB011", "OB021", "OB051", "OB061", "MOD001", "MOD021",
 "S101", "S071", "PORT011", "PORT012", "PORT021", "FORT001",
 "FORT002", "FORT003", "FORT004", "FORT005"]
 
 # List of what the rules used are checking for:
-# E000 io-error, C001 missing implicit none,
+# E000 io-error, E001 syntax-error, C001 missing implicit none,
 # C021 real literal missing kind suffix,
 # C022 implicit-real-kind, C031 magic-number-in-array-size,
 # C032 magic unit in IO statement, C043 missing-action-specifier,

--- a/rose-stem/app/check_fortitude_linter/file/fortitude.toml
+++ b/rose-stem/app/check_fortitude_linter/file/fortitude.toml
@@ -62,7 +62,7 @@ output-format = "grouped"                #group results by file
 
 # science/shared:
 "space_from_metadata_mod.F90" = ["C072"]
-"space_from_metadata_mod_test.pf=["E001","C121"]
+"space_from_metadata_mod_test.pf" = ["E001","C121"]
 
 # science/socrates_interface:
 "init_radiation_fields_alg_mod.x90" = ["S101"]

--- a/rose-stem/app/check_fortitude_linter/file/fortitude.toml
+++ b/rose-stem/app/check_fortitude_linter/file/fortitude.toml
@@ -8,14 +8,14 @@
 
 file-extensions= ["f90", "F90", "X90", "x90", "pf"]   #check these file types
 
-select = ["E000", "E001", "C001", "C021", "C022", "C031", "C032", "C043",
+select = ["E000", "C001", "C021", "C022", "C031", "C032", "C043",
 "C051", "C061", "C071", "C072", "C081", "C091", "C082", "C092", "C121",
 "C132", "C141", "OB011", "OB021", "OB051", "OB061", "MOD001", "MOD021",
 "S101", "S071", "PORT011", "PORT012", "PORT021", "FORT001",
 "FORT002", "FORT003", "FORT004", "FORT005"]
 
 # List of what the rules used are checking for:
-# E000 io-error, E001 syntax-error, C001 missing implicit none,
+# E000 io-error, C001 missing implicit none,
 # C021 real literal missing kind suffix,
 # C022 implicit-real-kind, C031 magic-number-in-array-size,
 # C032 magic unit in IO statement, C043 missing-action-specifier,

--- a/rose-stem/app/check_fortitude_linter/file/fortitude.toml
+++ b/rose-stem/app/check_fortitude_linter/file/fortitude.toml
@@ -6,7 +6,7 @@
 
 [check]
 
-file-extensions= ["f90", "F90", "X90", "x90","pf"]   #check these file types
+file-extensions= ["f90", "F90", "X90", "x90", "pf"]   #check these file types
 
 select = ["E000", "E001", "C001", "C021", "C022", "C031", "C032", "C043",
 "C051", "C061", "C071", "C072", "C081", "C091", "C082", "C092", "C121",

--- a/rose-stem/app/check_fortitude_linter/file/fortitude.toml
+++ b/rose-stem/app/check_fortitude_linter/file/fortitude.toml
@@ -6,7 +6,7 @@
 
 [check]
 
-file-extensions= ["f90", "F90", "X90", "x90"]   #check these file types
+file-extensions= ["f90", "F90", "X90", "x90","pf"]   #check these file types
 
 select = ["E000", "E001", "C001", "C021", "C022", "C031", "C032", "C043",
 "C051", "C061", "C071", "C072", "C081", "C091", "C082", "C092", "C121",
@@ -62,6 +62,7 @@ output-format = "grouped"                #group results by file
 
 # science/shared:
 "space_from_metadata_mod.F90" = ["C072"]
+"space_from_metadata_mod_test.pf=["E001","C121"]
 
 # science/socrates_interface:
 "init_radiation_fields_alg_mod.x90" = ["S101"]

--- a/science/shared/source/vector_space/space_from_metadata_mod.F90
+++ b/science/shared/source/vector_space/space_from_metadata_mod.F90
@@ -70,7 +70,7 @@ contains
   function trim_string_start_arrow(string) result(newstring)
     character(*), intent(inout) :: string
     character(:), allocatable :: newstring
-    character(5) :: arrow_prefix = ' --> '
+    character(5), parameter :: arrow_prefix = ' --> '
     if ( string(1:5) == arrow_prefix ) then
     newstring = string(6:)
     else


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: <!-- SR id, filled by author when ready for review (e.g. @octocat) --> @mo-lucy-gordon 
Code Reviewer: <!-- CR id, filled by SSD/CCD (e.g. @octocat) --> @james-bruten-mo 

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

This PR fixes the fortitude issues raised in the nightly tests by switching off checks the E001 and C121 in `science/shared/unit-test/vector_space/space_from_metadata_mod_test.pf` and correcting the arrow_prefix variable in `science/shared/source/vector_space/space_from_metadata_mod.F90` . 

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] I have tested this change locally, using the LFRic Apps rose-stem suite
- [x] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [x] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [x] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

# Test Suite Results - lfric_apps - fix_fortitude_shared/run8

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [fix_fortitude_shared/run8](https://cylchub/services/cylc-review/cycles/pierre.siddall/?suite=fix_fortitude_shared%2Frun8) |
| Suite User | pierre.siddall |
| Workflow Start | 2026-04-30T08:42:39 |
| Groups Run | developer |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| casim | [MetOffice/casim@2026.03.2](https://github.com/MetOffice/casim/tree/2026.03.2) | True |
| jules | [MetOffice/jules@2026.03.2](https://github.com/MetOffice/jules/tree/2026.03.2) | True |
| lfric_apps | [Pierre-siddall/lfric_apps@fix-shared-fortitude](https://github.com/Pierre-siddall/lfric_apps/tree/fix-shared-fortitude) | False |
| lfric_core | [MetOffice/lfric_core@3c8ccc6](https://github.com/MetOffice/lfric_core/tree/3c8ccc6) | True |
| moci | [MetOffice/moci@2026.03.2](https://github.com/MetOffice/moci/tree/2026.03.2) | True |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@cab3315](https://github.com/MetOffice/SimSys_Scripts/tree/cab3315) | True |
| socrates | [MetOffice/socrates@2026.03.2](https://github.com/MetOffice/socrates/tree/2026.03.2) | True |
| socrates-spectral | [MetOffice/socrates-spectral@2026.03.2](https://github.com/MetOffice/socrates-spectral/tree/2026.03.2) | True |
| ukca | [MetOffice/ukca@1cdb9c2](https://github.com/MetOffice/ukca/tree/1cdb9c2) | True |

## Task Information
:white_check_mark: succeeded tasks - 1185


<!-- Paste your trac.log from testing output here -->

## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [x] Sensitive data is properly handled (if applicable)
- [x] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [x] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [x] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [x] I understand this area of code and the changes being added
- [x] The proposed changes correspond to the pull request description
- [x] Documentation is sufficient (do documentation papers need updating)
- [x] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable

