### PR TITLE
apply macro from #77

### DIFF
--- a/applications/adjoint_tests/rose-meta/lfric-adjoint_tests/versions.py
+++ b/applications/adjoint_tests/rose-meta/lfric-adjoint_tests/versions.py
@@ -239,3 +239,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/applications/gravity_wave/rose-meta/lfric-gravity_wave/versions.py
+++ b/applications/gravity_wave/rose-meta/lfric-gravity_wave/versions.py
@@ -204,3 +204,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/applications/gungho_model/rose-meta/lfric-gungho_model/versions.py
+++ b/applications/gungho_model/rose-meta/lfric-gungho_model/versions.py
@@ -204,3 +204,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/applications/jedi_lfric_tests/rose-meta/jedi_common/versions.py
+++ b/applications/jedi_lfric_tests/rose-meta/jedi_common/versions.py
@@ -239,3 +239,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/applications/jedi_lfric_tests/rose-meta/jedi_forecast/versions.py
+++ b/applications/jedi_lfric_tests/rose-meta/jedi_forecast/versions.py
@@ -239,3 +239,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/applications/jedi_lfric_tests/rose-meta/jedi_forecast_pseudo/versions.py
+++ b/applications/jedi_lfric_tests/rose-meta/jedi_forecast_pseudo/versions.py
@@ -239,3 +239,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/applications/jedi_lfric_tests/rose-meta/jedi_id_tlm_tests/versions.py
+++ b/applications/jedi_lfric_tests/rose-meta/jedi_id_tlm_tests/versions.py
@@ -239,3 +239,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/applications/jedi_lfric_tests/rose-meta/jedi_lfric_tests/versions.py
+++ b/applications/jedi_lfric_tests/rose-meta/jedi_lfric_tests/versions.py
@@ -239,3 +239,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/applications/jedi_lfric_tests/rose-meta/jedi_tlm_forecast_tl/versions.py
+++ b/applications/jedi_lfric_tests/rose-meta/jedi_tlm_forecast_tl/versions.py
@@ -239,3 +239,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/applications/jedi_lfric_tests/rose-meta/jedi_tlm_tests/versions.py
+++ b/applications/jedi_lfric_tests/rose-meta/jedi_tlm_tests/versions.py
@@ -239,3 +239,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/applications/jules/rose-meta/lfric-jules/versions.py
+++ b/applications/jules/rose-meta/lfric-jules/versions.py
@@ -204,3 +204,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/applications/lfric2lfric/rose-meta/lfric-lfric2lfric/versions.py
+++ b/applications/lfric2lfric/rose-meta/lfric-lfric2lfric/versions.py
@@ -223,3 +223,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/applications/lfric_atm/rose-meta/lfric-lfric_atm/versions.py
+++ b/applications/lfric_atm/rose-meta/lfric-lfric_atm/versions.py
@@ -204,3 +204,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/applications/lfric_coupled/rose-meta/lfric-lfric_coupled/versions.py
+++ b/applications/lfric_coupled/rose-meta/lfric-lfric_coupled/versions.py
@@ -204,3 +204,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/applications/linear_model/rose-meta/lfric-linear_model/versions.py
+++ b/applications/linear_model/rose-meta/lfric-linear_model/versions.py
@@ -204,3 +204,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/applications/name_transport/rose-meta/lfric-name_transport/versions.py
+++ b/applications/name_transport/rose-meta/lfric-name_transport/versions.py
@@ -204,3 +204,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/applications/ngarch/rose-meta/lfric-ngarch/versions.py
+++ b/applications/ngarch/rose-meta/lfric-ngarch/versions.py
@@ -204,3 +204,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/applications/shallow_water/rose-meta/lfric-shallow_water/versions.py
+++ b/applications/shallow_water/rose-meta/lfric-shallow_water/versions.py
@@ -204,3 +204,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/applications/transport/rose-meta/lfric-transport/versions.py
+++ b/applications/transport/rose-meta/lfric-transport/versions.py
@@ -204,3 +204,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/interfaces/coupled_interface/rose-meta/coupling/versions.py
+++ b/interfaces/coupled_interface/rose-meta/coupling/versions.py
@@ -204,3 +204,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/interfaces/jedi_lfric_interface/rose-meta/jedi_lfric_interface/versions.py
+++ b/interfaces/jedi_lfric_interface/rose-meta/jedi_lfric_interface/versions.py
@@ -204,3 +204,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/rose-stem/app/adjoint_tests/rose-app.conf
+++ b/rose-stem/app/adjoint_tests/rose-app.conf
@@ -1,4 +1,4 @@
-meta=lfric-adjoint_tests/vn3.1_t249
+meta=lfric-adjoint_tests/vn3.1_t77
 
 [command]
 default=rose env-cat iodef_temp.xml -o iodef.xml; $LAUNCH_SCRIPT/launch-exe
@@ -608,6 +608,7 @@ write_conservation_diag=.false.
 write_diag=.true.
 write_dump=.false.
 write_fluxes=.false.
+write_initial=.true.
 write_minmax_tseries=.false.
 
 [!!namelist:jules_hydrology]

--- a/rose-stem/app/gravity_wave/rose-app.conf
+++ b/rose-stem/app/gravity_wave/rose-app.conf
@@ -1,4 +1,4 @@
-meta=lfric-gravity_wave/vn3.1_t249
+meta=lfric-gravity_wave/vn3.1_t77
 
 [command]
 default=$CORE_ROOT_DIR/bin/tweak_iodef; \
@@ -576,6 +576,7 @@ write_conservation_diag=.false.
 write_diag=.true.
 write_dump=.false.
 write_fluxes=.false.
+write_initial=.true.
 write_minmax_tseries=.false.
 
 [!!namelist:jules_hydrology]

--- a/rose-stem/app/gungho_model/rose-app.conf
+++ b/rose-stem/app/gungho_model/rose-app.conf
@@ -1,4 +1,4 @@
-meta=lfric-gungho_model/vn3.1_t249
+meta=lfric-gungho_model/vn3.1_t77
 
 [command]
 default=$CORE_ROOT_DIR/bin/tweak_iodef ; \
@@ -595,6 +595,7 @@ write_conservation_diag=.false.
 write_diag=.true.
 write_dump=.false.
 write_fluxes=.false.
+write_initial=.true.
 write_minmax_tseries=.false.
 
 [!!namelist:jules_hydrology]

--- a/rose-stem/app/jedi_forecast/rose-app.conf
+++ b/rose-stem/app/jedi_forecast/rose-app.conf
@@ -1,4 +1,4 @@
-meta=jedi_forecast/vn3.1_t249
+meta=jedi_forecast/vn3.1_t77
 
 [command]
 default=$CORE_ROOT_DIR/bin/tweak_iodef ; \
@@ -605,6 +605,7 @@ write_conservation_diag=.false.
 write_diag=.false.
 write_dump=.false.
 write_fluxes=.false.
+write_initial=.true.
 !!write_minmax_tseries=.false.
 
 [namelist:jedi_geometry]

--- a/rose-stem/app/jedi_forecast_pseudo/rose-app.conf
+++ b/rose-stem/app/jedi_forecast_pseudo/rose-app.conf
@@ -1,4 +1,4 @@
-meta=jedi_forecast_pseudo/vn3.1_t249
+meta=jedi_forecast_pseudo/vn3.1_t77
 
 [command]
 default=$CORE_ROOT_DIR/bin/tweak_iodef; \
@@ -602,6 +602,7 @@ write_conservation_diag=.false.
 write_diag=.true.
 write_dump=.false.
 write_fluxes=.false.
+write_initial=.true.
 write_minmax_tseries=.false.
 
 [namelist:jedi_geometry]

--- a/rose-stem/app/jedi_id_tlm_tests/rose-app.conf
+++ b/rose-stem/app/jedi_id_tlm_tests/rose-app.conf
@@ -1,4 +1,4 @@
-meta=jedi_id_tlm_tests/vn3.1_t249
+meta=jedi_id_tlm_tests/vn3.1_t77
 
 [command]
 default=$CORE_ROOT_DIR/bin/tweak_iodef; \
@@ -616,6 +616,7 @@ write_conservation_diag=.false.
 write_diag=.true.
 write_dump=.false.
 write_fluxes=.false.
+write_initial=.true.
 write_minmax_tseries=.false.
 
 [namelist:jedi_geometry]

--- a/rose-stem/app/jedi_lfric_tests/rose-app.conf
+++ b/rose-stem/app/jedi_lfric_tests/rose-app.conf
@@ -1,4 +1,4 @@
-meta=jedi_lfric_tests/vn3.1_t249
+meta=jedi_lfric_tests/vn3.1_t77
 
 [command]
 default=rose env-cat iodef_temp.xml -o iodef.xml; $LAUNCH_SCRIPT/launch-exe
@@ -615,6 +615,7 @@ write_conservation_diag=.false.
 write_diag=.true.
 write_dump=.false.
 write_fluxes=.false.
+write_initial=.true.
 write_minmax_tseries=.false.
 
 [namelist:jedi_geometry]

--- a/rose-stem/app/jedi_tlm_forecast_tl/rose-app.conf
+++ b/rose-stem/app/jedi_tlm_forecast_tl/rose-app.conf
@@ -1,4 +1,4 @@
-meta=jedi_tlm_forecast_tl/vn3.1_t249
+meta=jedi_tlm_forecast_tl/vn3.1_t77
 
 [command]
 default=$CORE_ROOT_DIR/bin/tweak_iodef; \
@@ -616,6 +616,7 @@ write_conservation_diag=.false.
 write_diag=.true.
 write_dump=.false.
 write_fluxes=.false.
+write_initial=.true.
 write_minmax_tseries=.false.
 
 [namelist:jedi_geometry]

--- a/rose-stem/app/jedi_tlm_tests/rose-app.conf
+++ b/rose-stem/app/jedi_tlm_tests/rose-app.conf
@@ -1,4 +1,4 @@
-meta=jedi_tlm_tests/vn3.1_t249
+meta=jedi_tlm_tests/vn3.1_t77
 
 [command]
 default=$CORE_ROOT_DIR/bin/tweak_iodef; \
@@ -616,6 +616,7 @@ write_conservation_diag=.false.
 write_diag=.true.
 write_dump=.false.
 write_fluxes=.false.
+write_initial=.true.
 write_minmax_tseries=.false.
 
 [namelist:jedi_geometry]

--- a/rose-stem/app/jules/rose-app.conf
+++ b/rose-stem/app/jules/rose-app.conf
@@ -1,4 +1,4 @@
-meta=lfric-jules/vn3.1_t249
+meta=lfric-jules/vn3.1_t77
 
 [command]
 default=$CORE_ROOT_DIR/bin/tweak_iodef; \
@@ -664,6 +664,7 @@ write_conservation_diag=.false.
 write_diag=.true.
 write_dump=.false.
 write_fluxes=.false.
+write_initial=.true.
 write_minmax_tseries=.false.
 
 [namelist:jules_hydrology]

--- a/rose-stem/app/lfric2lfric/rose-app.conf
+++ b/rose-stem/app/lfric2lfric/rose-app.conf
@@ -1,4 +1,4 @@
-meta=lfric-lfric2lfric/vn3.1_t249
+meta=lfric-lfric2lfric/vn3.1_t77
 
 [command]
 default=$CORE_ROOT_DIR/bin/tweak_iodef; \
@@ -532,6 +532,7 @@ write_conservation_diag=.false.
 write_diag=.true.
 write_dump=.false.
 write_fluxes=.false.
+write_initial=.true.
 write_minmax_tseries=.false.
 
 [!!namelist:jules_hydrology]

--- a/rose-stem/app/lfric_atm/rose-app.conf
+++ b/rose-stem/app/lfric_atm/rose-app.conf
@@ -1,4 +1,4 @@
-meta=lfric-lfric_atm/vn3.1_t249
+meta=lfric-lfric_atm/vn3.1_t77
 
 [command]
 default=$CORE_ROOT_DIR/bin/tweak_iodef; \
@@ -618,6 +618,7 @@ write_conservation_diag=.false.
 write_diag=.true.
 write_dump=.false.
 write_fluxes=.false.
+write_initial=.true.
 write_minmax_tseries=.false.
 
 [namelist:jules_hydrology]

--- a/rose-stem/app/lfric_coupled_atmosphere/rose-app.conf
+++ b/rose-stem/app/lfric_coupled_atmosphere/rose-app.conf
@@ -1,4 +1,4 @@
-meta=lfric-lfric_atm/vn3.1_t249
+meta=lfric-lfric_atm/vn3.1_t77
 
 [command]
 default=$CORE_ROOT_DIR/bin/tweak_iodef; \
@@ -614,6 +614,7 @@ write_conservation_diag=.false.
 write_diag=.true.
 write_dump=.false.
 write_fluxes=.false.
+write_initial=.true.
 write_minmax_tseries=.false.
 
 [namelist:jules_hydrology]

--- a/rose-stem/app/linear_model/rose-app.conf
+++ b/rose-stem/app/linear_model/rose-app.conf
@@ -1,4 +1,4 @@
-meta=lfric-linear_model/vn3.1_t249
+meta=lfric-linear_model/vn3.1_t77
 
 [command]
 default=rose env-cat iodef_temp.xml -o iodef.xml; $LAUNCH_SCRIPT/launch-exe
@@ -604,6 +604,7 @@ write_conservation_diag=.false.
 write_diag=.true.
 write_dump=.false.
 write_fluxes=.false.
+write_initial=.true.
 write_minmax_tseries=.false.
 
 [!!namelist:jules_hydrology]

--- a/rose-stem/app/name_transport/rose-app.conf
+++ b/rose-stem/app/name_transport/rose-app.conf
@@ -1,4 +1,4 @@
-meta=lfric-name_transport/vn3.1_t249
+meta=lfric-name_transport/vn3.1_t77
 
 [command]
 default=$CORE_ROOT_DIR/bin/tweak_iodef; \
@@ -583,6 +583,7 @@ write_conservation_diag=.false.
 write_diag=.true.
 write_dump=.false.
 write_fluxes=.false.
+write_initial=.true.
 write_minmax_tseries=.false.
 
 [!!namelist:jules_hydrology]

--- a/rose-stem/app/ngarch/rose-app.conf
+++ b/rose-stem/app/ngarch/rose-app.conf
@@ -1,4 +1,4 @@
-meta=lfric-ngarch/vn3.1_t249
+meta=lfric-ngarch/vn3.1_t77
 
 [command]
 default=$CORE_ROOT_DIR/bin/tweak_iodef; \
@@ -648,6 +648,7 @@ write_conservation_diag=.false.
 write_diag=.true.
 write_dump=.false.
 write_fluxes=.false.
+write_initial=.true.
 write_minmax_tseries=.false.
 
 [namelist:jules_hydrology]

--- a/rose-stem/app/shallow_water/rose-app.conf
+++ b/rose-stem/app/shallow_water/rose-app.conf
@@ -1,4 +1,4 @@
-meta=lfric-shallow_water/vn3.1_t249
+meta=lfric-shallow_water/vn3.1_t77
 
 [command]
 default=$CORE_ROOT_DIR/bin/tweak_iodef; \
@@ -568,6 +568,7 @@ write_conservation_diag=.false.
 write_diag=.true.
 write_dump=.false.
 write_fluxes=.false.
+write_initial=.true.
 write_minmax_tseries=.false.
 
 [!!namelist:jules_hydrology]

--- a/rose-stem/app/transport/rose-app.conf
+++ b/rose-stem/app/transport/rose-app.conf
@@ -1,4 +1,4 @@
-meta=lfric-transport/vn3.1_t249
+meta=lfric-transport/vn3.1_t77
 
 [command]
 default=$CORE_ROOT_DIR/bin/tweak_iodef; \
@@ -582,6 +582,7 @@ write_conservation_diag=.false.
 write_diag=.true.
 write_dump=.false.
 write_fluxes=.false.
+write_initial=.true.
 write_minmax_tseries=.false.
 
 [!!namelist:jules_hydrology]

--- a/science/adjoint/rose-meta/lfric-adjoint/versions.py
+++ b/science/adjoint/rose-meta/lfric-adjoint/versions.py
@@ -224,3 +224,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports

--- a/science/gungho/rose-meta/lfric-gungho/versions.py
+++ b/science/gungho/rose-meta/lfric-gungho/versions.py
@@ -159,7 +159,6 @@ class vn31_t382(MacroUpgrade):
         self.change_setting_value(
             config, ["namelist:physics", "bl_segment"], "16"
         )
-
         return config, self.reports
 
 
@@ -173,11 +172,9 @@ class vn31_t243(MacroUpgrade):
         # Commands From: rose-meta/um-microphysics
         nml = "namelist:microphysics"
         self.add_setting(config, [nml, "l_improve_precfrac_checks"], ".false.")
-
         # Commands From: rose-meta/um-cloud
         nml = "namelist:cloud"
         self.add_setting(config, [nml, "l_ensure_max_in_cloud_pc2"], ".false.")
-
         return config, self.reports
 
 
@@ -193,8 +190,8 @@ class vn31_t249(MacroUpgrade):
         # (apps using the new option 'smooth_fix' under the existing
         #  multi-option switch 'pc2_init_logic' fail checks against
         #  the existing meta-data).
-
         return config, self.reports
+
 
 class vn31_t77(MacroUpgrade):
     """Upgrade macro for ticket #77 by Mike Hobson."""
@@ -203,6 +200,7 @@ class vn31_t77(MacroUpgrade):
     AFTER_TAG = "vn3.1_t77"
 
     def upgrade(self, config, meta_config=None):
-        # Add settings
+        # Commands From: rose-meta/lfric-gungho
         self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
         return config, self.reports

--- a/science/linear/rose-meta/lfric-linear/versions.py
+++ b/science/linear/rose-meta/lfric-linear/versions.py
@@ -204,3 +204,16 @@ class vn31_t249(MacroUpgrade):
         #  the existing meta-data).
 
         return config, self.reports
+
+
+class vn31_t77(MacroUpgrade):
+    """Upgrade macro for ticket #77 by Mike Hobson."""
+
+    BEFORE_TAG = "vn3.1_t249"
+    AFTER_TAG = "vn3.1_t77"
+
+    def upgrade(self, config, meta_config=None):
+        # Commands From: rose-meta/lfric-gungho
+        self.add_setting(config, ["namelist:io", "write_initial"], ".true.")
+
+        return config, self.reports


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: <!-- SR id, filled by author when ready for review (e.g. @octocat) -->
Code Reviewer: @t00sa

<!-- To be completed by the developer -->

This was tested with the macro applied, but it wasn't pushed back to main. Testing is at https://cylchub/services/cylc-review/cycles/james.bruten/?suite=test_missed_macro%2Frun1

This has happened a few times, so we will look at whether the check_missing_macro script can be used in CI to help protect against it.

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [ ] Comments have been included that aid understanding and enhance the readability of the code
- [ ] My changes generate no new warnings
- [ ] All automated checks in the CI pipeline have completed successfully

## Testing

- [ ] I have tested this change locally, using the LFRic Apps rose-stem suite
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

## Security Considerations

- [ ] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
