### PR TITLE
PP import transmute fix

### DIFF
--- a/interfaces/build/pre_process_phys.mk
+++ b/interfaces/build/pre_process_phys.mk
@@ -14,10 +14,10 @@ TRANSMUTE_INCLUDE_METHOD ?= specify_include
 #
 MACRO_ARGS := $(addprefix -D,$(PRE_PROCESS_MACROS))
 
-# Find the specific files we wish to pre process and psyclone from physics source
+# Find the specific files we wish to transmute psyclone from physics source
 # Set our target dependency to the version of the file we are to generate after
 # The preprocessing step. #
-# .xu90 files are to represent preprocessed source, bound for psyclone,
+# .xu90 files are to represent preprocessed source, bound for transmute psyclone,
 # but are not psykal files, denoted by .x90
 #
 ifeq ("$(TRANSMUTE_INCLUDE_METHOD)", "specify_include")
@@ -49,25 +49,8 @@ include $(LFRIC_BUILD)/fortran.mk
 #
 pre_process: $(SOURCE_xu_FILES)
 
-# Make a copy of target file,
-# Preprocess target file,
-# Remove original F90, see psyclone step
+# Move the pre-processed source to an .xu90 file
 #
-# For the nvidia compiler, they only output into f90,
-# we need to move any f90 files to xu90 files for psyclone.
-# It also seems to place them at the root of the working dir.
-# See ticket Apps#624 for further context
-#
-ifeq ("$(FORTRAN_COMPILER)", "nvfortran")
-$(SOURCE_DIR)/%.xu90: $(SOURCE_DIR)/%.F90
-	echo Pre processing $<
-	$(FPP) $(FPPFLAGS) $(MACRO_ARGS) -o $@ $<
+$(SOURCE_DIR)/%.xu90: $(SOURCE_DIR)/%.f90
+	echo Moving $< to xu90 for Transmute
 	-mv $(SOURCE_DIR)/$*.f90 $@
-	-mv $(shell basename $*.f90) $@
-	rm $<
-else
-$(SOURCE_DIR)/%.xu90: $(SOURCE_DIR)/%.F90
-	echo Pre processing $<
-	$(FPP) $(FPPFLAGS) $(MACRO_ARGS) $< >$@
-	rm $<
-endif

--- a/interfaces/build/pre_process_phys.mk
+++ b/interfaces/build/pre_process_phys.mk
@@ -22,8 +22,8 @@ MACRO_ARGS := $(addprefix -D,$(PRE_PROCESS_MACROS))
 #
 ifeq ("$(TRANSMUTE_INCLUDE_METHOD)", "specify_include")
 # For CPU OMP method, we want specific files
-	SOURCE_xu_FILES := $(foreach THE_FILE, $(PSYCLONE_PHYSICS_FILES), $(patsubst $(SOURCE_DIR)/%.F90, $(SOURCE_DIR)/%.xu90, $(shell find $(SOURCE_DIR) -name '$(THE_FILE).F90' -print)))
-	SOURCE_xu_FILES += $(foreach THE_FILE, $(PSYCLONE_PASS_NO_SCRIPT), $(patsubst $(SOURCE_DIR)/%.F90, $(SOURCE_DIR)/%.xu90, $(shell find $(SOURCE_DIR) -name '$(THE_FILE).F90' -print)))
+	SOURCE_xu_FILES := $(foreach THE_FILE, $(PSYCLONE_PHYSICS_FILES), $(patsubst $(SOURCE_DIR)/%.f90, $(SOURCE_DIR)/%.xu90, $(shell find $(SOURCE_DIR) -name '$(THE_FILE).f90' -print)))
+	SOURCE_xu_FILES += $(foreach THE_FILE, $(PSYCLONE_PASS_NO_SCRIPT), $(patsubst $(SOURCE_DIR)/%.f90, $(SOURCE_DIR)/%.xu90, $(shell find $(SOURCE_DIR) -name '$(THE_FILE).f90' -print)))
 else ifeq ("$(TRANSMUTE_INCLUDE_METHOD)", "specify_exclude")
 # For the offload method, we want to filter out specific files, and psyclone the rest
 # We don't want to wildcard the whole working directory, this will cause problems. 
@@ -32,8 +32,8 @@ else ifeq ("$(TRANSMUTE_INCLUDE_METHOD)", "specify_exclude")
 # pre-processed.
 	ifneq ($(strip $(PSYCLONE_DIRECTORIES)),)
 		EXTEND_DIR_FULL_PATH := $(foreach THE_DIRECTORY, $(PSYCLONE_DIRECTORIES), $(shell find $(SOURCE_DIR) -name $(THE_DIRECTORY) -print))
-		SOURCE_xu_FILES_FULL := $(strip $(foreach THE_PSY_DIR, $(EXTEND_DIR_FULL_PATH), $(patsubst $(SOURCE_DIR)/%.F90, $(SOURCE_DIR)/%.xu90, $(shell find $(THE_PSY_DIR) -name '*.F90' -print))))
-		SOURCE_xu_EXCEPTION := $(strip $(foreach THE_FILE, $(PSYCLONE_PHYSICS_EXCEPTION), $(patsubst $(SOURCE_DIR)/%.F90, $(SOURCE_DIR)/%.xu90, $(shell find $(SOURCE_DIR) -name '$(THE_FILE).F90' -print))))
+		SOURCE_xu_FILES_FULL := $(strip $(foreach THE_PSY_DIR, $(EXTEND_DIR_FULL_PATH), $(patsubst $(SOURCE_DIR)/%.f90, $(SOURCE_DIR)/%.xu90, $(shell find $(THE_PSY_DIR) -name '*.f90' -print))))
+		SOURCE_xu_EXCEPTION := $(strip $(foreach THE_FILE, $(PSYCLONE_PHYSICS_EXCEPTION), $(patsubst $(SOURCE_DIR)/%.f90, $(SOURCE_DIR)/%.xu90, $(shell find $(SOURCE_DIR) -name '$(THE_FILE).f90' -print))))
 		SOURCE_xu_FILES := $(filter-out $(SOURCE_xu_EXCEPTION), $(SOURCE_xu_FILES_FULL))
 	endif
 endif


### PR DESCRIPTION
# PR Summary

There are some core changes coming which will mean that all source is pre-processed on import. 
This means that our pre-prcoess step no longer is needed as is, but instead is needed to move the `f90` file to an `ux90` file, so that Transmute can run and produce a `f90` file, but with the Transmute updates.

Sci/Tech Reviewer: <!-- SR id, filled by author when ready for review (e.g. @octocat) -->
Code Reviewer: <!-- CR id, filled by SSD/CCD (e.g. @octocat) -->

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [ ] Comments have been included that aid understanding and enhance the readability of the code
- [ ] My changes generate no new warnings
- [ ] All automated checks in the CI pipeline have completed successfully

## Testing

- [ ] I have tested this change locally, using the LFRic Apps rose-stem suite
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

## Security Considerations

- [ ] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
