### PR TITLE
Linear FFSL transport fix

### DIFF
--- a/rose-stem/site/meto/kgos/linear_model/azspice/checksum_linear_model_dcmip301_ffsl-C24_azspice_gnu_fast-debug-64bit.txt
+++ b/rose-stem/site/meto/kgos/linear_model/azspice/checksum_linear_model_dcmip301_ffsl-C24_azspice_gnu_fast-debug-64bit.txt
@@ -1,3 +1,3 @@
-Inner product checksum rho = 3F3ECDE1F4FB6D71
-Inner product checksum theta = 403900D0276360C7
-Inner product checksum u = 433886D1B3AC62F7
+Inner product checksum rho = 3F206E3D410FBAA1
+Inner product checksum theta = 40336C44D1223058
+Inner product checksum u = 43315AD096E775C8

--- a/rose-stem/site/meto/kgos/linear_model/azspice/checksum_linear_model_nwp_gal9_ffsl-C12_MG_azspice_gnu_fast-debug-64bit.txt
+++ b/rose-stem/site/meto/kgos/linear_model/azspice/checksum_linear_model_nwp_gal9_ffsl-C12_MG_azspice_gnu_fast-debug-64bit.txt
@@ -1,9 +1,9 @@
-Inner product checksum rho = 3FB4D4110CA3D006
-Inner product checksum theta = 4176FC5FE5D25085
-Inner product checksum u = 457446349725B318
-Inner product checksum mr1 = 3F96FA911560E0DA
-Inner product checksum mr2 = 3F73B14A84B157D1
-Inner product checksum mr3 = 3EF232FA8D9A10DC
-Inner product checksum mr4 = 3EF2C71109D8CFD1
+Inner product checksum rho = 3FB39A87256EFBA4
+Inner product checksum theta = 4178F73E0895947C
+Inner product checksum u = 4575A243D6EF5308
+Inner product checksum mr1 = 3F971B941E744F40
+Inner product checksum mr2 = 3F73B22CD9690E0F
+Inner product checksum mr3 = 3EF2330E82B700E8
+Inner product checksum mr4 = 3EF2D46607B02008
 Inner product checksum mr5 =                0
 Inner product checksum mr6 =                0

--- a/rose-stem/site/meto/kgos/linear_model/ex1a/checksum_linear_model_dcmip301_ffsl-C24_ex1a_gnu_fast-debug-64bit.txt
+++ b/rose-stem/site/meto/kgos/linear_model/ex1a/checksum_linear_model_dcmip301_ffsl-C24_ex1a_gnu_fast-debug-64bit.txt
@@ -1,3 +1,3 @@
-Inner product checksum rho = 3F3ECDE126CB7FF1
-Inner product checksum theta = 403900CE84CF39C1
-Inner product checksum u = 433886D85FEF51D6
+Inner product checksum rho = 3F206E54AEF5C1B3
+Inner product checksum theta = 40336C41A6DDB3BE
+Inner product checksum u = 43315AD6E24E5839

--- a/rose-stem/site/meto/kgos/linear_model/ex1a/checksum_linear_model_nwp_gal9_ffsl-C12_MG_ex1a_gnu_fast-debug-64bit.txt
+++ b/rose-stem/site/meto/kgos/linear_model/ex1a/checksum_linear_model_nwp_gal9_ffsl-C12_MG_ex1a_gnu_fast-debug-64bit.txt
@@ -1,9 +1,9 @@
-Inner product checksum rho = 3FB4D40E571EE886
-Inner product checksum theta = 4176FC5F90D8B500
-Inner product checksum u = 457446346BCAB332
-Inner product checksum mr1 = 3F96FA90D870A36B
-Inner product checksum mr2 = 3F73B14A84A19D55
-Inner product checksum mr3 = 3EF232FA8E4D60E5
-Inner product checksum mr4 = 3EF2C7110D6C5B11
+Inner product checksum rho = 3FB39A8B517D5F2E
+Inner product checksum theta = 4178F73E618D29F2
+Inner product checksum u = 4575A2441EFE8B68
+Inner product checksum mr1 = 3F971B9893A5643A
+Inner product checksum mr2 = 3F73B22CD971A5AF
+Inner product checksum mr3 = 3EF2330E8371FCB3
+Inner product checksum mr4 = 3EF2D4660B84F2F1
 Inner product checksum mr5 =                0
 Inner product checksum mr6 =                0

--- a/science/linear/source/driver/linear_diagnostics_driver_mod.F90
+++ b/science/linear/source/driver/linear_diagnostics_driver_mod.F90
@@ -245,6 +245,8 @@ contains
       do i=1,nummr
         call write_scalar_diagnostic( 'ls_'//trim(mr_names(i)), ls_mr(i), &
                                       modeldb%clock, mesh, nodal_output_on_w3 )
+        call write_scalar_diagnostic( trim(mr_names(i)), mr(i),           &
+                                      modeldb%clock, mesh, nodal_output_on_w3 )
       end do
     end if
 

--- a/science/linear/source/kernel/transport/ffsl/tl_ffsl_flux_xy_kernel_mod.F90
+++ b/science/linear/source/kernel/transport/ffsl/tl_ffsl_flux_xy_kernel_mod.F90
@@ -449,7 +449,7 @@ contains
     integer(kind=i_def) :: local_dofs(2)
 
     ! Local scalars
-    integer(kind=i_def) :: dof_iterator
+    integer(kind=i_def) :: df_idx, df
     integer(kind=i_def) :: dof_offset
     integer(kind=i_def) :: k, j, w2h_idx, idx_dep, col_idx
     integer(kind=i_def) :: rel_idx_k
@@ -478,14 +478,15 @@ contains
 
 
     ! Loop over the direction dofs to compute flux at each dof -----------------
-    do dof_iterator = 1, face_selector(map_w3_2d(1))
+    do df_idx = 1, ABS(face_selector(map_w3_2d(1)))
+      df = local_dofs(df_idx - MIN(0, face_selector(map_w3_2d(1))))
 
       ! Pull out index to avoid multiple indirections
-      w2h_idx = map_w2h(local_dofs(dof_iterator))
-      idx_dep = map_depk(local_dofs(dof_iterator)) + ndep_half
+      w2h_idx = map_w2h(df)
+      idx_dep = map_depk(df) + ndep_half
 
       ! Set a local offset, dependent on the face we are looping over
-      select case (local_dofs(dof_iterator))
+      select case (df)
       case (W, S)
         dof_offset = 0
       case (E, N)
@@ -625,7 +626,7 @@ contains
       flux_ls(w2h_idx : w2h_idx+nlayers-1) = inv_dt * (                        &
         recon_ls_field(:) * frac_wind_pert(w2h_idx : w2h_idx+nlayers-1)        &
       )
-    end do ! dof_iterator
+    end do ! df_idx
 
   end subroutine tl_ffsl_flux_xy_1d
 

--- a/science/linear/source/kernel/transport/ffsl/tl_ffsl_flux_xy_sphere_kernel_mod.F90
+++ b/science/linear/source/kernel/transport/ffsl/tl_ffsl_flux_xy_sphere_kernel_mod.F90
@@ -604,7 +604,7 @@ contains
     integer(kind=i_def) :: local_dofs(2)
 
     ! Local scalars
-    integer(kind=i_def) :: dof_iterator
+    integer(kind=i_def) :: df_idx, df
     integer(kind=i_def) :: col_idx, rel_idx_k
     integer(kind=i_def) :: dof_offset
     integer(kind=i_def) :: k, j, w2h_idx, idx_dep
@@ -652,14 +652,15 @@ contains
     end if
 
     ! Loop over the direction dofs to compute flux at each dof -----------------
-    do dof_iterator = 1, face_selector(map_w3_2d(1))
+    do df_idx = 1, ABS(face_selector(map_w3_2d(1)))
+      df = local_dofs(df_idx - MIN(0, face_selector(map_w3_2d(1))))
 
       ! Pull out index to avoid multiple indirections
-      w2h_idx = map_w2h(local_dofs(dof_iterator))
-      idx_dep = map_depk(local_dofs(dof_iterator)) + ndep_half
+      w2h_idx = map_w2h(df)
+      idx_dep = map_depk(df) + ndep_half
 
       ! Set a local offset, dependent on the face we are looping over
-      select case (local_dofs(dof_iterator))
+      select case (df)
       case ( W, S )
         dof_offset = 0
       case ( E, N )
@@ -825,7 +826,7 @@ contains
       flux_ls(w2h_idx : w2h_idx+nlayers-1) = inv_dt * (                        &
         recon_ls_field(:) * frac_wind_pert(w2h_idx : w2h_idx+nlayers-1)        &
       )
-    end do ! dof_iterator
+    end do ! df_idx
 
   end subroutine tl_ffsl_flux_xy_sphere_1d
 


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: @tommbendall  <!-- SR id, filled by author when ready for review (e.g. @octocat) -->
Code Reviewer: @Pierre-siddall 

<!-- To be completed by the developer -->

PR414 (https://github.com/MetOffice/lfric_apps/pull/414) added the FFSL transport to the linear model. Since going onto main it has been found that the `face_selector` routines had changed between vn3.1 (when 414 started) and main (when 414 was merged on), and thus the FFSL routines need to be updated to use them properly. 

Separately, it was found that on main the plots of moisture for the linear model were incorrect as it was not being outputted correctly. This has also been fixed on this PR. 

The plots below show how u has changed with the FFSL fix for the DCMIP test, and how the noise has gone away. The NWP test shows what the m_cf looked like on mian, and how it looks now. 

The test suite all passes, except for the linear model FFSL kgo changes. 

FFSL DCMIP u on main

<img width="2000" height="1000" alt="ffsl_u_broken" src="https://github.com/user-attachments/assets/e6bcee81-2e6f-48a4-88b0-b5b9110a2354" />

FFSL DCMIP u on branch

<img width="2000" height="1000" alt="ffsl_u_fix" src="https://github.com/user-attachments/assets/84ca0706-fa32-4370-ae8f-21d666d9dfc8" />

NWP GAL9 C12 m_cf on main

<img width="2000" height="1000" alt="nwp_mcf_broken" src="https://github.com/user-attachments/assets/b9d7a794-f5c7-4cc9-9c34-65ceddab3b50" />

NWP GAL9 C12 m_cf on branch

<img width="2000" height="1000" alt="nwp_mcf_fix" src="https://github.com/user-attachments/assets/f299f97d-60d1-4f3a-b584-0d853013d479" />


<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [ ] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] I have tested this change locally, using the LFRic Apps rose-stem suite
- [x] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

# Test Suite Results - lfric_apps - ffsl_linear_fix/run5

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [ffsl_linear_fix/run5](https://cylchub/services/cylc-review/cycles/james.kent/?suite=ffsl_linear_fix%2Frun5) |
| Suite User | james.kent |
| Workflow Start | 2026-06-26T14:03:01 |
| Groups Run | all |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| casim | [MetOffice/casim@2026.03.2](https://github.com/MetOffice/casim/tree/2026.03.2) | True |
| jules | [MetOffice/jules@1ea67b4](https://github.com/MetOffice/jules/tree/1ea67b4) | True |
| lfric_apps | [jameskent-metoffice/lfric_apps@ffsl_linear_fix](https://github.com/jameskent-metoffice/lfric_apps/tree/ffsl_linear_fix) | False |
| lfric_core | [MetOffice/lfric_core@b2374d3](https://github.com/MetOffice/lfric_core/tree/b2374d3) | True |
| moci | [MetOffice/moci@2026.03.2](https://github.com/MetOffice/moci/tree/2026.03.2) | True |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@3e2998b](https://github.com/MetOffice/SimSys_Scripts/tree/3e2998b) | True |
| socrates | [MetOffice/socrates@2026.03.2](https://github.com/MetOffice/socrates/tree/2026.03.2) | True |
| socrates-spectral | [MetOffice/socrates-spectral@2026.03.2](https://github.com/MetOffice/socrates-spectral/tree/2026.03.2) | True |
| ukca | [MetOffice/ukca@1cdb9c2](https://github.com/MetOffice/ukca/tree/1cdb9c2) | True |

## Task Information
<details>
<summary>:x: failed tasks - 4</summary>

| Task | State |
| :--- | :--- |
| check_linear_model_dcmip301_ffsl-C24_azspice_gnu_fast-debug-64bit | failed |
| check_linear_model_dcmip301_ffsl-C24_ex1a_gnu_fast-debug-64bit | failed |
| check_linear_model_nwp_gal9_ffsl-C12_MG_azspice_gnu_fast-debug-64bit | failed |
| check_linear_model_nwp_gal9_ffsl-C12_MG_ex1a_gnu_fast-debug-64bit | failed |
</details>
:white_check_mark: succeeded tasks - 1589
<details>
<summary>:hourglass: waiting tasks - 2</summary>

| Task | State |
| :--- | :--- |
| housekeep_azspice | waiting |
| housekeep_ex1a | waiting |
</details>

## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [x] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [x] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [x] I understand this area of code and the changes being added
- [x] The proposed changes correspond to the pull request description
- [x] Documentation is sufficient (do documentation papers need updating)
- [x] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
