### PR TITLE
update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -70,9 +70,11 @@ rose-stem/templates/                   @james-bruten-mo                    # @je
 rose-stem/lib/                         @james-bruten-mo                    # @jennyhickson
 rose-stem/bin/                         @james-bruten-mo                    # @jennyhickson
 rose-stem/site/meto/common/            @james-bruten-mo                    # @jennyhickson
+rose-stem/site/meto/groups.cylc        @james-bruten-mo                    # @jennyhickson
 rose-stem/site/meto/macros/            @james-bruten-mo                    # @jennyhickson
+rose-stem/site/meto/suite_config.cylc  @james-bruten-mo                    # @jennyhickson
+rose-stem/site/meto/variables.cylc     @james-bruten-mo                    # @jennyhickson
 rose-stem/site/azngarch                @james-bruten-mo                    # @jennyhickson
-rose-stem/site/meto                    @james-bruten-mo                    # @jennyhickson
 rose-stem/site/esnz                    @tinyendian @JorgeBornemann
 rose-stem/site/ncas                    @SimonWNCAS
 rose-stem/site/nci                     @davelee2804

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -99,20 +99,20 @@ rose-stem/site/common/ngarch/              @christophermaynard @james-bruten-mo 
 rose-stem/site/common/shallow_water/       @jameskent-metoffice @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
 rose-stem/site/common/solver/              @christophermaynard @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
 rose-stem/site/common/transport/           @tommbendall @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
-rose-stem/site/meto/kgos/adjoint*/         @DrTVockerodtMO @james-bruten-mo
-rose-stem/site/meto/kgos/gravity_wave/     @thomasmelvin @james-bruten-mo
-rose-stem/site/meto/kgos/gungho*/          @thomasmelvin @james-bruten-mo
-rose-stem/site/meto/kgos/jedi*/            @ss421 @james-bruten-mo
-rose-stem/site/meto/kgos/jules/            @iboutle @james-bruten-mo
-rose-stem/site/meto/kgos/lfric2lfric/      @mo-lottieturner @james-bruten-mo
-rose-stem/site/meto/kgos/lfric_atm/        @iboutle @james-bruten-mo
-rose-stem/site/meto/kgos/lfricinputs/      @mo-lottieturner @james-bruten-mo
-rose-stem/site/meto/kgos/linear*/          @cjohnson-pi @james-bruten-mo
-rose-stem/site/meto/kgos/name_transport/   @jameskent-metoffice @james-bruten-mo
-rose-stem/site/meto/kgos/ngarch/           @christophermaynard @james-bruten-mo
-rose-stem/site/meto/kgos/shallow_water/    @jameskent-metoffice @james-bruten-mo
-rose-stem/site/meto/kgos/solver/           @christophermaynard @james-bruten-mo
-rose-stem/site/meto/kgos/transport/        @tommbendall @james-bruten-mo
+rose-stem/site/meto/kgos/adjoint*/         @DrTVockerodtMO
+rose-stem/site/meto/kgos/gravity_wave/     @thomasmelvin
+rose-stem/site/meto/kgos/gungho*/          @thomasmelvin
+rose-stem/site/meto/kgos/jedi*/            @ss421
+rose-stem/site/meto/kgos/jules/            @iboutle
+rose-stem/site/meto/kgos/lfric2lfric/      @mo-lottieturner
+rose-stem/site/meto/kgos/lfric_atm/        @iboutle
+rose-stem/site/meto/kgos/lfricinputs/      @mo-lottieturner
+rose-stem/site/meto/kgos/linear*/          @cjohnson-pi
+rose-stem/site/meto/kgos/name_transport/   @jameskent-metoffice
+rose-stem/site/meto/kgos/ngarch/           @christophermaynard
+rose-stem/site/meto/kgos/shallow_water/    @jameskent-metoffice
+rose-stem/site/meto/kgos/solver/           @christophermaynard
+rose-stem/site/meto/kgos/transport/        @tommbendall
 
 # Other areas
 documentation                           # @MetOffice/ssdteam

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -71,7 +71,6 @@ rose-stem/lib/                         @james-bruten-mo                    # @je
 rose-stem/bin/                         @james-bruten-mo                    # @jennyhickson
 rose-stem/site/meto/common/            @james-bruten-mo                    # @jennyhickson
 rose-stem/site/meto/macros/            @james-bruten-mo                    # @jennyhickson
-rose-stem/site/common                  @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
 rose-stem/site/azngarch                @james-bruten-mo                    # @jennyhickson
 rose-stem/site/meto                    @james-bruten-mo                    # @jennyhickson
 rose-stem/site/esnz                    @tinyendian @JorgeBornemann
@@ -84,6 +83,36 @@ interfaces/build/                      @christophermaynard
 **/*Makefile                           @MatthewHambley @hiker
 **/*.mk                                @MatthewHambley @hiker
 **/optimisation                        @christophermaynard                 # HPC Optimisation Team
+
+# Rose Stem Application Settings
+rose-stem/site/common/adjoint*/            @DrTVockerodtMO @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
+rose-stem/site/common/gravity_wave/        @thomasmelvin @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
+rose-stem/site/common/gungho*/             @thomasmelvin @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
+rose-stem/site/common/jedi*/               @ss421 @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
+rose-stem/site/common/jules/               @iboutle @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
+rose-stem/site/common/lfric2lfric/         @mo-lottieturner @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
+rose-stem/site/common/lfric_atm/           @iboutle @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
+rose-stem/site/common/lfricinputs/         @mo-lottieturner @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
+rose-stem/site/common/linear*/             @cjohnson-pi @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
+rose-stem/site/common/name_transport/      @jameskent-metoffice @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
+rose-stem/site/common/ngarch/              @christophermaynard @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
+rose-stem/site/common/shallow_water/       @jameskent-metoffice @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
+rose-stem/site/common/solver/              @christophermaynard @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
+rose-stem/site/common/transport/           @tommbendall @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
+rose-stem/site/meto/kgos/adjoint*/         @DrTVockerodtMO @james-bruten-mo
+rose-stem/site/meto/kgos/gravity_wave/     @thomasmelvin @james-bruten-mo
+rose-stem/site/meto/kgos/gungho*/          @thomasmelvin @james-bruten-mo
+rose-stem/site/meto/kgos/jedi*/            @ss421 @james-bruten-mo
+rose-stem/site/meto/kgos/jules/            @iboutle @james-bruten-mo
+rose-stem/site/meto/kgos/lfric2lfric/      @mo-lottieturner @james-bruten-mo
+rose-stem/site/meto/kgos/lfric_atm/        @iboutle @james-bruten-mo
+rose-stem/site/meto/kgos/lfricinputs/      @mo-lottieturner @james-bruten-mo
+rose-stem/site/meto/kgos/linear*/          @cjohnson-pi @james-bruten-mo
+rose-stem/site/meto/kgos/name_transport/   @jameskent-metoffice @james-bruten-mo
+rose-stem/site/meto/kgos/ngarch/           @christophermaynard @james-bruten-mo
+rose-stem/site/meto/kgos/shallow_water/    @jameskent-metoffice @james-bruten-mo
+rose-stem/site/meto/kgos/solver/           @christophermaynard @james-bruten-mo
+rose-stem/site/meto/kgos/transport/        @tommbendall @james-bruten-mo
 
 # Other areas
 documentation                           # @MetOffice/ssdteam

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -101,20 +101,6 @@ rose-stem/site/common/ngarch/              @christophermaynard @james-bruten-mo 
 rose-stem/site/common/shallow_water/       @jameskent-metoffice @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
 rose-stem/site/common/solver/              @christophermaynard @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
 rose-stem/site/common/transport/           @tommbendall @james-bruten-mo @tinyendian @JorgeBornemann @SimonWNCAS @davelee2804  # @jennyhickson
-rose-stem/site/meto/kgos/adjoint*/         @DrTVockerodtMO
-rose-stem/site/meto/kgos/gravity_wave/     @thomasmelvin
-rose-stem/site/meto/kgos/gungho*/          @thomasmelvin
-rose-stem/site/meto/kgos/jedi*/            @ss421
-rose-stem/site/meto/kgos/jules/            @iboutle
-rose-stem/site/meto/kgos/lfric2lfric/      @mo-lottieturner
-rose-stem/site/meto/kgos/lfric_atm/        @iboutle
-rose-stem/site/meto/kgos/lfricinputs/      @mo-lottieturner
-rose-stem/site/meto/kgos/linear*/          @cjohnson-pi
-rose-stem/site/meto/kgos/name_transport/   @jameskent-metoffice
-rose-stem/site/meto/kgos/ngarch/           @christophermaynard
-rose-stem/site/meto/kgos/shallow_water/    @jameskent-metoffice
-rose-stem/site/meto/kgos/solver/           @christophermaynard
-rose-stem/site/meto/kgos/transport/        @tommbendall
 
 # Other areas
 documentation                           # @MetOffice/ssdteam


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: <!-- SR id, filled by author when ready for review (e.g. @octocat) -->
Code Reviewer: @t00sa

<!-- To be completed by the developer -->

The addition of site owners for `site/common` into the codeowners file means that actual application owners no longer get notified of changes there. This unfortunately needs hardcoding per application. 
A similar change to `site/meto` means kgo approvals come to me, instead of to the application, so fine tune the meto site codeowners settings slightly.

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [ ] Comments have been included that aid understanding and enhance the readability of the code
- [ ] My changes generate no new warnings
- [ ] All automated checks in the CI pipeline have completed successfully

## Testing

- [ ] I have tested this change locally, using the LFRic Apps rose-stem suite
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

## Security Considerations

- [ ] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
