### PR TITLE
Fetch dtheta_mphys only where the microphysics scheme uses it

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,6 +2,7 @@
 
 | GitHub user         | Real Name           | Affiliation                      | Date         |
 | ------------------- | ------------------- | -------------------------------- | ------------ |
+| ickc                | Kolen Cheung        | University of Exeter             | 2026-07-22   |
 | jedbakerMO          | Jed Baker           | Met Office                       | 2025-12-29   |
 | tommbendall         | Thomas Bendall      | Met Office                       | 2026-01-13   |
 | iboutle             | Ian Boutle          | Met Office                       | 2026-03-06   |

--- a/science/gungho/source/algorithm/physics/slow_physics_alg_mod.X90
+++ b/science/gungho/source/algorithm/physics/slow_physics_alg_mod.X90
@@ -559,11 +559,14 @@ contains
     !--------------------------------------------------------------------
     ! UM microphysics scheme
     !--------------------------------------------------------------------
-    call microphysics_fields%get_field('dtheta_mphys', dtheta_mphys)
     call clone_bundle(mr_n, dmr_mphys, nummr)
     call set_bundle_scalar(0.0_r_def, dmr_mphys, nummr)
     if ( microphysics == microphysics_um .and. &
          microphysics_placement == microphysics_placement_slow) then
+      ! The UM physics fields are only created when at least one of the
+      ! sections in the create_physics_prognostics guard is active, so this
+      ! field can only be fetched where it is used.
+      call microphysics_fields%get_field('dtheta_mphys', dtheta_mphys)
       if ( microphysics_casim ) then
         call casim_alg( modeldb%config, mr_n, theta, rho,                &
                         derived_fields, microphysics_fields,             &


### PR DESCRIPTION
Any "dynamics + external forcing only" configuration -- one where every section switch guarding UM physics field creation is 'none' -- aborts at the start of the slow physics with:

    ERROR: get_field: No 64-bit field [dtheta_mphys] in field collection:
           microphysics_fields

This is a regression introduced by #502, which wrapped the whole UM_PHYSICS block of create_physics_prognostics_mod.F90 in a new guard:

    if ( surface            /= surface_none            .or. &
         radiation          /= radiation_none          .or. &
         orographic_drag    /= orographic_drag_none    .or. &
         stochastic_physics /= stochastic_physics_none .or. &
         boundary_layer     /= boundary_layer_none ) then

With all five of those switches set to 'none' the microphysics increment fields (dtheta_mphys, dmv_mphys, ...) are no longer created, but slow_physics_alg_mod fetched dtheta_mphys unconditionally, ahead of the

    if ( microphysics == microphysics_um .and. &
         microphysics_placement == microphysics_placement_slow ) then

block that is the only code which fills it. Every other reference to the field -- the post_mphys branch of the electric scheme and the increment collection at the end of the algorithm -- is already gated on microphysics_done, so this fetch was the sole unguarded reference. It is also the only unguarded microphysics_fields%get_field in the tree; the two 'precfrac' fetches in fast_physics_alg_mod and semi_implicit_timestep_alg_mod are both already inside scheme guards.

The fix is applied to the consumer rather than to the creation guard. Adding `microphysics /= microphysics_none` to the guard in create_physics_prognostics_mod would not help these configurations, because their microphysics section is 'none' as well: the field would still not be created and the unguarded fetch would still abort. Moving the fetch inside the block that uses it makes the algorithm consistent with how it already treats every other UM physics field, and leaves the behaviour of every configuration that does run microphysics unchanged (the pointer is declared `=> null()` and is only dereferenced under microphysics_done).

Note that #502 also added `microphysics` and `microphysics_none` to the section_choice_config_mod import list of create_physics_prognostics_mod but never used them, which suggests the omission of microphysics from the new guard was an oversight. Those imports are left in place here so that the fix stays minimal; they can be removed, or the guard completed, independently of this change.

Found on Isambard 3 (Cray EX, GCC 14.3) running the forcing-only configurations of the u-dr932 and u-dt000 suites against a 2026.07.1 / vn3.2 build; both complete their runs with this change applied.

# PR Summary

Sci/Tech Reviewer: @iboutle 
Code Reviewer: @mattatmet 

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] I have tested this change locally, using the LFRic Apps rose-stem suite
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [x] I understand this area of code and the changes being added
- [x] The proposed changes correspond to the pull request description
- [x] Documentation is sufficient (do documentation papers need updating)
- [x] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [x] All dependencies have been resolved
- [x] Related Issues have been properly linked and addressed
- [x] CLA compliance has been confirmed
- [x] Code quality standards have been met
- [x] Tests are adequate and have passed
- [x] Documentation is complete and accurate
- [x] Security considerations have been addressed
- [x] Performance impact is acceptable
