### PR TITLE
Read weights on pe0

### DIFF
--- a/applications/lfricinputs/source/common/lfricinp_initialise_mod.f90
+++ b/applications/lfricinputs/source/common/lfricinp_initialise_mod.f90
@@ -22,7 +22,7 @@ public :: lfricinp_initialise, lfricinp_get_command_line_args
 
 contains
 
-!> Initialises generic lfricinputs infrastructure
+!> Reads the command line that contains namelist file names
 !> @param [out] program_fname Filename for program specific namelists provided
 !>                            on the command line
 subroutine lfricinp_get_command_line_args(program_fname)
@@ -32,7 +32,6 @@ subroutine lfricinp_get_command_line_args(program_fname)
 
   character(len=fnamelen), intent(out) :: program_fname
 
-  call log_event('Reading command line', LOG_LEVEL_INFO)
   call lfricinp_read_command_line_args(program_fname, lfric_nl_fname, io_fname)
 
 end subroutine lfricinp_get_command_line_args

--- a/applications/lfricinputs/source/common/lfricinp_initialise_mod.f90
+++ b/applications/lfricinputs/source/common/lfricinp_initialise_mod.f90
@@ -18,27 +18,33 @@ implicit none
 
 private
 
-public :: lfricinp_initialise
+public :: lfricinp_initialise, lfricinp_get_command_line_args
 
 contains
 
 !> Initialises generic lfricinputs infrastructure
 !> @param [out] program_fname Filename for program specific namelists provided
 !>                            on the command line
-subroutine lfricinp_initialise(program_fname)
+subroutine lfricinp_get_command_line_args(program_fname)
   use lfricinp_read_command_line_args_mod, only: lfricinp_read_command_line_args
-  use lfricinp_setup_io_mod,          only: io_config, io_fname
-  use lfricinp_regrid_options_mod, only: lfricinp_init_regrid_options
-  use lfricinp_datetime_mod, only: datetime
-  use lfricinp_stash_to_lfric_map_mod, only: lfricinp_init_stash_to_lfric_map
-  use lfricinp_lfric_driver_mod, only: lfric_nl_fname
-
-  implicit none
+  use lfricinp_setup_io_mod,               only: io_fname
+  use lfricinp_lfric_driver_mod,           only: lfric_nl_fname
 
   character(len=fnamelen), intent(out) :: program_fname
 
   call log_event('Reading command line', LOG_LEVEL_INFO)
   call lfricinp_read_command_line_args(program_fname, lfric_nl_fname, io_fname)
+
+end subroutine lfricinp_get_command_line_args
+
+!> Initialises generic lfricinputs infrastructure
+subroutine lfricinp_initialise(program_fname)
+  use lfricinp_setup_io_mod,          only: io_config
+  use lfricinp_regrid_options_mod, only: lfricinp_init_regrid_options
+  use lfricinp_datetime_mod, only: datetime
+  use lfricinp_stash_to_lfric_map_mod, only: lfricinp_init_stash_to_lfric_map
+
+  character(len=fnamelen), intent(in) :: program_fname
 
   call log_event('Loading IO namelist', LOG_LEVEL_INFO)
   call io_config%load_namelist()

--- a/applications/lfricinputs/source/common/lfricinp_lfric_driver_mod.f90
+++ b/applications/lfricinputs/source/common/lfricinp_lfric_driver_mod.f90
@@ -56,8 +56,8 @@ use lfricinp_um_parameters_mod, only: fnamelen
 implicit none
 
 private
-public :: lfricinp_initialise_lfric, lfricinp_finalise_lfric, lfric_fields,    &
-          io_context
+public :: lfricinp_initialise_lfric, lfricinp_setup_basics, lfricinp_finalise_lfric, &
+          lfric_fields, io_context
 
 ! Input namelist configuration
 character(len=fnamelen), public :: lfric_nl_fname
@@ -84,26 +84,60 @@ type(lfric_xios_context_type), target :: io_context
 
 contains
 
-function lfricinp_initialise_lfric(program_name_arg,                         &
-                                   required_lfric_namelists,                 &
+function lfricinp_setup_basics(program_name_arg,          &
+                               required_lfric_namelists)  &
+                               result(config)
+  character(len=*),    intent(in) :: program_name_arg
+  character(len=*),    intent(in) :: required_lfric_namelists(:)
+
+  type(config_type) :: config
+
+
+  ! Set module variables
+  program_name = program_name_arg
+  xios_id = trim(program_name) // "_client"
+
+  ! Initialise MPI and create the default communicator: mpi_comm_world
+  call create_comm(comm)
+
+  ! Initialise xios
+  call lfric_xios_initialise( program_name, comm, .false. )
+
+  ! Save LFRic's part of the split communicator for later use, and
+  ! set the total number of ranks and the local rank of the split
+  ! communicator
+  call global_mpi%initialise(comm)
+  total_ranks = global_mpi%get_comm_size()
+  local_rank = global_mpi%get_comm_rank()
+
+  ! Initialise halo functionality
+  call initialise_halo_comms( comm )
+
+  call config%initialise( program_name_arg )
+
+  call load_configuration( lfric_nl_fname, required_lfric_namelists, config )
+
+  ! Initialise logging system
+  call init_logger( config, comm, program_name )
+
+end function lfricinp_setup_basics
+
+subroutine lfricinp_initialise_lfric(config,                                 &
                                    start_date, time_origin,                  &
                                    first_step, last_step,                    &
-                                   spinup_period, seconds_per_step)          &
-                            result(config)
+                                   spinup_period, seconds_per_step)
+
 
 ! Description:
 !  Initialises LFRic infrastructure, MPI, XIOS and halos.
 
 implicit none
 
-character(len=*),    intent(in) :: program_name_arg
-character(len=*),    intent(in) :: required_lfric_namelists(:)
+type(config_type),   intent(inout) :: config
 character(len=*),    intent(in) :: start_date, time_origin
 integer(kind=i_def), intent(in) :: first_step, last_step
 real(r_second),      intent(in) :: spinup_period
 real(r_second),      intent(in) :: seconds_per_step
-
-type(config_type) :: config
 
 type(step_calendar_type), allocatable :: model_calendar
 type(linked_list_type),   pointer     :: file_list => null()
@@ -142,33 +176,6 @@ integer(i_def) :: tile_size_y
 
 integer(i_def), allocatable :: tile_size(:,:)
 !=====================================================================
-
-! Set module variables
-program_name = program_name_arg
-xios_id = trim(program_name) // "_client"
-
-! Initialise MPI and create the default communicator: mpi_comm_world
-call create_comm(comm)
-
-! Initialise xios
-call lfric_xios_initialise( program_name, comm, .false. )
-
-! Save LFRic's part of the split communicator for later use, and
-! set the total number of ranks and the local rank of the split
-! communicator
-call global_mpi%initialise(comm)
-total_ranks = global_mpi%get_comm_size()
-local_rank = global_mpi%get_comm_rank()
-
-!Initialise halo functionality
-call initialise_halo_comms( comm )
-
-call config%initialise( program_name_arg )
-
-call load_configuration( lfric_nl_fname, required_lfric_namelists, config )
-
-! Initialise logging system
-call init_logger( config, comm, program_name )
 
 call init_collections()
 
@@ -286,7 +293,7 @@ call advance(io_context, model_clock)
 
 nullify(chi, panel_id, chi_inventory, panel_id_inventory)
 
-end function lfricinp_initialise_lfric
+end subroutine lfricinp_initialise_lfric
 
 !------------------------------------------------------------------
 

--- a/applications/lfricinputs/source/common/lfricinp_lfric_driver_mod.f90
+++ b/applications/lfricinputs/source/common/lfricinp_lfric_driver_mod.f90
@@ -318,9 +318,6 @@ integer              :: i
 
 allocate(success_map(size(required_lfric_namelists)))
 
-call log_event('Loading '//trim(program_name)//' configuration ...',           &
-               LOG_LEVEL_ALWAYS)
-
 call read_configuration( lfric_nl, config=config )
 
 okay = ensure_configuration(required_lfric_namelists, success_map)

--- a/applications/lfricinputs/source/lfric2um.f90
+++ b/applications/lfricinputs/source/lfric2um.f90
@@ -11,8 +11,10 @@ use config_mod, only: config_type
 use lfricinp_create_lfric_fields_mod,     only: lfricinp_create_lfric_fields
 use lfricinp_um_grid_mod,                 only: um_grid
 use lfricinp_datetime_mod,                only: datetime
-use lfricinp_initialise_mod,              only: lfricinp_initialise
+use lfricinp_initialise_mod,              only: lfricinp_initialise,           &
+                                                lfricinp_get_command_line_args
 use lfricinp_lfric_driver_mod,            only: lfricinp_initialise_lfric,     &
+                                                lfricinp_setup_basics,         &
                                                 lfricinp_finalise_lfric, mesh, &
                                                 twod_mesh,                     &
                                                 lfric_fields
@@ -34,6 +36,11 @@ type(config_type), save :: lfric_config
 ! Read inputs and initialise setup
 !==========================================================================
 ! Read command line arguments and return details of filenames.
+call lfricinp_get_command_line_args(lfric2um_nl_fname)
+
+lfric_config = lfricinp_setup_basics(program_name_arg="lfric2um",              &
+                         required_lfric_namelists = required_lfric_namelists)
+
 ! Initialise common infrastructure
 call lfricinp_initialise(lfric2um_nl_fname)
 
@@ -41,9 +48,8 @@ call lfricinp_initialise(lfric2um_nl_fname)
 call lfric2um_initialise_lfric2um()
 
 ! Initialise LFRic Infrastructure
-lfric_config = lfricinp_initialise_lfric(                                      &
-     program_name_arg="lfric2um",                                              &
-     required_lfric_namelists = required_lfric_namelists,                      &
+call lfricinp_initialise_lfric(                                                &
+     config=lfric_config,                                                      &
      start_date = datetime % first_validity_time,                              &
      time_origin = datetime % first_validity_time,                             &
      first_step = datetime % first_step,                                       &

--- a/applications/lfricinputs/source/lfric2um.f90
+++ b/applications/lfricinputs/source/lfric2um.f90
@@ -30,7 +30,7 @@ use lfric2um_main_loop_mod,               only: lfric2um_main_loop
 
 implicit none
 
-type(config_type), save :: lfric_config
+type(config_type) :: lfric_config
 
 !==========================================================================
 ! Read inputs and initialise setup
@@ -38,16 +38,17 @@ type(config_type), save :: lfric_config
 ! Read command line arguments and return details of filenames.
 call lfricinp_get_command_line_args(lfric2um_nl_fname)
 
+! Read the LFRic infrastructure namelist and set up MPI, XIOS and logger
 lfric_config = lfricinp_setup_basics(program_name_arg="lfric2um",              &
                          required_lfric_namelists = required_lfric_namelists)
 
-! Initialise common infrastructure
+! Read common regridding configuration
 call lfricinp_initialise(lfric2um_nl_fname)
 
-! Initialise lfric2um
+! Read lfric2um configuration, STASHmaster and regrid weights
 call lfric2um_initialise_lfric2um()
 
-! Initialise LFRic Infrastructure
+! Initialise rest of LFRic Infrastructure
 call lfricinp_initialise_lfric(                                                &
      config=lfric_config,                                                      &
      start_date = datetime % first_validity_time,                              &

--- a/applications/lfricinputs/source/lfric2um/lfric2um_initialise_lfric2um_mod.f90
+++ b/applications/lfricinputs/source/lfric2um/lfric2um_initialise_lfric2um_mod.f90
@@ -20,6 +20,7 @@ subroutine lfric2um_initialise_lfric2um()
 use lfric2um_namelists_mod, only: lfric2um_config
 use lfricinp_stashmaster_mod, only: lfricinp_read_stashmaster
 use lfricinp_stash_to_lfric_map_mod, only: lfricinp_init_stash_to_lfric_map
+use lfricinp_lfric_driver_mod,         only: local_rank
 use lfric2um_regrid_weights_mod, only: lfric2um_regrid_weightsfile_ctl
 implicit none
 
@@ -29,8 +30,10 @@ call lfric2um_config%load_namelists()
 ! Read in STASHmaster file
 call lfricinp_read_stashmaster(lfric2um_config%stashmaster_file)
 
-! Read in weights files
-call lfric2um_regrid_weightsfile_ctl()
+if (local_rank == 0) then
+  ! Read in weights files
+  call lfric2um_regrid_weightsfile_ctl()
+end if
 
 end subroutine lfric2um_initialise_lfric2um
 

--- a/applications/lfricinputs/source/lfric2um/lfric2um_main_loop_mod.f90
+++ b/applications/lfricinputs/source/lfric2um/lfric2um_main_loop_mod.f90
@@ -79,23 +79,23 @@ do i_stash = 1, lfric2um_config%num_fields
   num_levels = lfricinp_get_num_levels(um_output_file, stashcode)
 
   !---------------------------------------------------------------------------
-  ! Select appropriate weights
-  !---------------------------------------------------------------------------
-  weights => get_weights(stashcode)
-
-  !---------------------------------------------------------------------------
   ! Get pointer to lfric field + read
   !---------------------------------------------------------------------------
   call lfric_fields%get_field(get_field_name(stashcode), lfric_field)
   call lfric_field%read_field("read_"//lfric_field%get_name())
 
   !---------------------------------------------------------------------------
-  ! Allocate space for global data, only need full field on rank 0
+  ! Allocate space for global data and get weights. Only on rank 0
   !---------------------------------------------------------------------------
   if (allocated(global_field_array)) deallocate(global_field_array)
   if (local_rank == 0) then
+    !---------------------------------------------------------------------------
+    ! Select appropriate weights
+    !---------------------------------------------------------------------------
+    weights => get_weights(stashcode)
     allocate(global_field_array(weights%num_points_src))
   else
+    nullify(weights)
     allocate(global_field_array(1))
   end if
 

--- a/applications/lfricinputs/source/scintelapi.f90
+++ b/applications/lfricinputs/source/scintelapi.f90
@@ -18,7 +18,7 @@ use dump_generator_mod,       only: dump_generator
 
 implicit none
 
-type(config_type), save :: lfric_config
+type(config_type) :: lfric_config
 
 ! Initialise the LFRic, XIOS, API, etc. infrastructure
 call scintelapi_initialise(lfric_config)

--- a/applications/lfricinputs/source/scintelapi/top_level/scintelapi_interface_mod.f90
+++ b/applications/lfricinputs/source/scintelapi/top_level/scintelapi_interface_mod.f90
@@ -34,7 +34,7 @@ use field_list_mod,            only: init_field_list
 use generator_library_mod,     only: init_generator_lib
 use dependency_graph_list_mod, only: init_dependency_graph_list
 use lfricinp_lfric_driver_mod, only: lfricinp_initialise_lfric, model_clock,   &
-                                     lfric_nl_fname
+                                     lfric_nl_fname, lfricinp_setup_basics
 use lfricinp_setup_io_mod,     only: io_fname
 use lfricinp_read_command_line_args_mod, only: lfricinp_read_command_line_args
 
@@ -53,10 +53,12 @@ call io_config%load_namelist()
 ! Load date and time information
 call datetime % initialise()
 
+lfric_config = lfricinp_setup_basics(program_name_arg="scintelapi",           &
+                required_lfric_namelists = required_lfric_namelists)
+
 ! Initialise LFRic infrastructure
-lfric_config = lfricinp_initialise_lfric(                                      &
-     program_name_arg="scintelapi",                                            &
-     required_lfric_namelists = required_lfric_namelists,                      &
+call lfricinp_initialise_lfric(                                                &
+     config=lfric_config,                                                      &
      start_date = datetime % first_validity_time,                              &
      time_origin = datetime % first_validity_time,                             &
      first_step = datetime % first_step,                                       &

--- a/applications/lfricinputs/source/um2lfric.f90
+++ b/applications/lfricinputs/source/um2lfric.f90
@@ -37,7 +37,7 @@ use um2lfric_read_um_file_mod,     only: um2lfric_close_um_file, &
 
 implicit none
 
-type(config_type), save :: lfric_config
+type(config_type) :: lfric_config
 
 !==========================================================================
 ! Read inputs and initialise setup
@@ -46,16 +46,17 @@ type(config_type), save :: lfric_config
 ! Read command line arguments and return details of filenames.
 call lfricinp_get_command_line_args(um2lfric_nl_fname)
 
-! Initialise common infrastructure
-call lfricinp_initialise(um2lfric_nl_fname)
-
-! Initialise um2lfric
-call um2lfric_initialise_um2lfric()
-
+! Read the LFRic infrastructure namelist and set up MPI, XIOS and logger
 lfric_config = lfricinp_setup_basics(program_name_arg="um2lfric",              &
                          required_lfric_namelists = required_lfric_namelists)
 
-! Initialise LFRic Infrastructure
+! Read common regridding configuration
+call lfricinp_initialise(um2lfric_nl_fname)
+
+! Read um2lfric configuration, STASHmaster and regrid weights
+call um2lfric_initialise_um2lfric()
+
+! Initialise rest of LFRic Infrastructure
 call lfricinp_initialise_lfric(                                                &
      config=lfric_config,                                                      &
      start_date = datetime % first_validity_time,                              &

--- a/applications/lfricinputs/source/um2lfric.f90
+++ b/applications/lfricinputs/source/um2lfric.f90
@@ -8,6 +8,7 @@ program um2lfric
 ! lfricinputs modules
 use config_mod,                    only: config_type
 use lfricinp_lfric_driver_mod,     only: lfricinp_initialise_lfric,     &
+                                         lfricinp_setup_basics,         &
                                          lfricinp_finalise_lfric, mesh, &
                                          twod_mesh, lfric_fields
 use lfricinp_ancils_mod,           only: lfricinp_create_ancil_fields, &
@@ -16,11 +17,12 @@ use lfricinp_create_lfric_fields_mod, &
                                    only: lfricinp_create_lfric_fields
 use lfricinp_um_grid_mod,          only: um_grid
 use lfricinp_datetime_mod,         only: datetime
-use lfricinp_initialise_mod,       only: lfricinp_initialise
+use lfricinp_initialise_mod,       only: lfricinp_initialise,           &
+                                         lfricinp_get_command_line_args
 
 ! um2lfric modules
-use um2lfric_namelist_mod,         only: um2lfric_nl_fname, &
-                                         um2lfric_config,   &
+use um2lfric_namelist_mod,         only: um2lfric_nl_fname,             &
+                                         um2lfric_config,               &
                                          required_lfric_namelists
 use um2lfric_initialise_um2lfric_mod, &
                                    only: um2lfric_initialise_um2lfric
@@ -42,16 +44,20 @@ type(config_type), save :: lfric_config
 !==========================================================================
 
 ! Read command line arguments and return details of filenames.
+call lfricinp_get_command_line_args(um2lfric_nl_fname)
+
 ! Initialise common infrastructure
 call lfricinp_initialise(um2lfric_nl_fname)
 
 ! Initialise um2lfric
 call um2lfric_initialise_um2lfric()
 
+lfric_config = lfricinp_setup_basics(program_name_arg="um2lfric",              &
+                         required_lfric_namelists = required_lfric_namelists)
+
 ! Initialise LFRic Infrastructure
-lfric_config = lfricinp_initialise_lfric(                                      &
-     program_name_arg="um2lfric",                                              &
-     required_lfric_namelists = required_lfric_namelists,                      &
+call lfricinp_initialise_lfric(                                                &
+     config=lfric_config,                                                      &
      start_date = datetime % first_validity_time,                              &
      time_origin = datetime % first_validity_time,                             &
      first_step = datetime % first_step,                                       &


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: @mike-hobson 
Code Reviewer: @mo-lottieturner 

<!-- To be completed by the developer -->

When run in parallel, all ranks of lfric2um and um2lfric read the regridding weights. However, regridding is only done on rank 0. The main purpose of this change is to read the weights only on rank 0. Doing so saves significant memory which is important when regridding at high resolution: the memory use of a C896-N1280 lfric2um run is reduced by 150GB when running on 108 ranks with 32 IO servers.

Unfortunately, to enable this to be done, some significant reordering of the application set-up needed to be done as MPI is not set up by the LFRic component till after the weights are read in. The reordering of the setup forms the bulk of the code changes in this branch.

The branch breaks the set-up into two. In the first part sets up MPI, but also the LFRic logger and XIOS. Setting up the LFRic logger early gives the benefit that a lot of log messages from the applications now go to the PET output whereas previously they ended up in stdout because they were sent before the logger had been initialised.

While lfric2um is the main target of this PR, parallel changes are made to um2lfric and the sciintelapi to maintain consistency between the applications.

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

closes #590 
closes #642 

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] I have tested this change locally, using the LFRic Apps rose-stem suite
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

# Test Suite Results - lfric_apps - read_weights_on_pe0/run1

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [read_weights_on_pe0/run1](https://cylchub/services/cylc-review/cycles/steve.mullerworth/?suite=read_weights_on_pe0%2Frun1) |
| Suite User | steve.mullerworth |
| Workflow Start | 2026-07-29T11:00:24 |
| Groups Run | developer |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| casim | [MetOffice/casim@2026.07.1](https://github.com/MetOffice/casim/tree/2026.07.1) | True |
| jules | [MetOffice/jules@2026.07.1](https://github.com/MetOffice/jules/tree/2026.07.1) | True |
| lfric_apps | [stevemullerworth/lfric_apps@read_weights_on_pe0](https://github.com/stevemullerworth/lfric_apps/tree/read_weights_on_pe0) | False |
| lfric_core | [MetOffice/lfric_core@2026.07.1](https://github.com/MetOffice/lfric_core/tree/2026.07.1) | True |
| moci | [MetOffice/moci@2026.07.1](https://github.com/MetOffice/moci/tree/2026.07.1) | True |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@2026.07.1](https://github.com/MetOffice/SimSys_Scripts/tree/2026.07.1) | True |
| socrates | [MetOffice/socrates@2026.07.1](https://github.com/MetOffice/socrates/tree/2026.07.1) | True |
| socrates-spectral | [MetOffice/socrates-spectral@2026.07.1](https://github.com/MetOffice/socrates-spectral/tree/2026.07.1) | True |
| ukca | [MetOffice/ukca@2026.07.1](https://github.com/MetOffice/ukca/tree/2026.07.1) | True |

## Task Information
:white_check_mark: succeeded tasks - 1208

<!-- Paste your trac.log from testing output here -->

## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [x] Sensitive data is properly handled (if applicable)
- [x] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [x] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [x] I understand this area of code and the changes being added
- [x] The proposed changes correspond to the pull request description
- [x] Documentation is sufficient (do documentation papers need updating)
- [x] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
