### PR TITLE
Convection diagnostics needed for PS49

### DIFF
--- a/applications/lfric_atm/metadata/field_def_diags.xml
+++ b/applications/lfric_atm/metadata/field_def_diags.xml
@@ -362,6 +362,7 @@
   <field id="convection__cca_2d" name="cca_2d" long_name="convective_cloud_amount_(2d)_with_no_anvil" unit="1" domain_ref="face" />
   <field id="convection__lowest_cca_2d" name="lowest_cca_2d" long_name="lowest_convective_cloud_amount_(2d)_with_no_anvil" unit="1" domain_ref="face" />
   <field id="convection__ccw" name="ccw" long_name="convective_cloud_water" unit="kg kg-1" grid_ref="full_level_face_grid" />
+  <field id="convection__ccw_unadjusted" name="ccw_unadjusted" long_name="convective_cloud_water_unadjusted_for_rad" unit="kg kg-1" grid_ref="full_level_face_grid" />
   <field id="convection__massflux_up" name="massflux_up" long_name="convection_upward_massflux" unit="Pa s-1" grid_ref="full_level_face_grid" />
   <field id="convection__massflux_up_half" name="massflux_up_half" long_name="conv_upward_massflux_half_levs" unit="Pa s-1" grid_ref="half_level_face_grid" />
   <field id="convection__massflux_up_cmpta" name="massflux_up_cmpta" long_name="conv_upward_mfx_component_a" unit="Pa s-1" grid_ref="half_level_face_grid" />

--- a/applications/lfric_atm/metadata/field_def_diags.xml
+++ b/applications/lfric_atm/metadata/field_def_diags.xml
@@ -408,6 +408,8 @@
   <field id="convection__pres_cv_top" name="pres_cv_top" long_name="pressure_at_convective_cloud_top" unit="Pa" domain_ref="face" />
   <field id="convection__conv_cloud_base_icao_height" name="convection_conv_cloud_base_icao_height" long_name="height_of_convective_cloud_base" unit="kft" domain_ref="face" />
   <field id="convection__conv_cloud_top_icao_height" name="convection_conv_cloud_top_icao_height" long_name="height_of_convective_cloud_top" unit="kft" domain_ref="face" />
+  <field id="convection__lowest_conv_cloud_base_icao_height" name="convection_lowest_conv_cloud_base_icao_height" long_name="height_of_lowest_convective_cloud_base" unit="kft" domain_ref="face" />
+  <field id="convection__lowest_conv_cloud_top_icao_height" name="convection_lowest_conv_cloud_top_icao_height" long_name="height_of_lowest_convective_cloud_top" unit="kft" domain_ref="face" />
   <!-- microphysics diagnostics -->
   <field id="microphysics__dtheta_mphys" name="dtheta_mphys" long_name="potential_temperature_increment_due_to_microphysics" unit="K" grid_ref="full_level_face_grid" />
   <field id="microphysics__dt_mphys" name="dt_mphys" long_name="temperature_increment_due_to_microphysics" unit="K" grid_ref="full_level_face_grid" />

--- a/applications/lfric_atm/metadata/field_def_diags.xml
+++ b/applications/lfric_atm/metadata/field_def_diags.xml
@@ -400,6 +400,7 @@
   <field id="convection__mid_in_col" name="mid_in_col" long_name="frequency_of_midlevel_convection" unit="1" domain_ref="face" />
   <field id="convection__mid_cfl_limited" name="mid_cfl_limited" long_name="midlevel_convection_cfl_limited" unit="1" domain_ref="face" />
   <field id="convection__cape_diluted" name="cape_diluted" long_name="cape_diluted" unit="J/kg" domain_ref="face" />
+  <field id="convection__cape_undilute" name="cape_undilute" long_name="cape_from_undilute_parcel_ascent" unit="J/kg" domain_ref="face" />
   <field id="convection__cape_timescale" name="cape_timescale" long_name="cape_timescale" unit="s" domain_ref="face" />
   <field id="convection__freeze_level" name="freeze_level" long_name="model_level_number_at_freezing_level" unit="1" domain_ref="face" />
   <field id="convection__pres_lowest_cv_base" name="pres_lowest_cv_base" long_name="pressure_at_lowest_convective_cloud_base" unit="Pa" domain_ref="face" />

--- a/applications/lfric_atm/optimisation/azngarch-sandbox/transmute/kernel/conv_gr_kernel_mod.py
+++ b/applications/lfric_atm/optimisation/azngarch-sandbox/transmute/kernel/conv_gr_kernel_mod.py
@@ -3,6 +3,9 @@
 # The file LICENCE, distributed with this code, contains details of the terms
 # under which the code may be used.
 # -----------------------------------------------------------------------------
+# Some of the content of this file has been produced with the assistance of
+# Anthropic Claude Opus 5 (Claude Code).
+# -----------------------------------------------------------------------------
 """
 PSyclone script for applying OpenMP transformations specific to the
 Gregory-Rowntree convection kernel.
@@ -240,6 +243,7 @@ ignore_dependencies_block2_after_numseg = [
     "mid_dt",
     "mid_dq",
     "cca_unadjusted",
+    "ccw_unadjusted",
     "massflux_up_half",
     "du_conv",
     "dv_conv",

--- a/applications/lfric_atm/optimisation/meto-ex1a/transmute/kernel/conv_gr_kernel_mod.py
+++ b/applications/lfric_atm/optimisation/meto-ex1a/transmute/kernel/conv_gr_kernel_mod.py
@@ -3,6 +3,9 @@
 # The file LICENCE, distributed with this code, contains details of the terms
 # under which the code may be used.
 # -----------------------------------------------------------------------------
+# Some of the content of this file has been produced with the assistance of
+# Anthropic Claude Opus 5 (Claude Code).
+# -----------------------------------------------------------------------------
 """
 PSyclone script for applying OpenMP transformations specific to the
 Gregory-Rowntree convection kernel.
@@ -40,7 +43,7 @@ false_dep_vars_all = [
     "conv_rain_3d", "conv_snow_3d", "entrain_up", "entrain_down",
     "detrain_up", "detrain_down", "dd_dt", "dd_dq", "deep_massflux",
     "deep_dt", "deep_dq", "shallow_massflux", "shallow_dt", "shallow_dq",
-    "mid_massflux", "mid_dt", "mid_dq", "cca_unadjusted",
+    "mid_massflux", "mid_dt", "mid_dq", "cca_unadjusted", "ccw_unadjusted",
     "massflux_up_half", "du_conv", "dv_conv", "dmv_conv",
     "conv_prog_precip", "conv_prog_precip", "dt_conv", "conv_prog_dtheta",
     "conv_prog_dmv", "dcfl_conv", "dcff_conv", "dbcf_conv", "dd_mf_cb",

--- a/applications/lfric_atm/optimisation/meto-ex1a/transmute/kernel/script_options.py
+++ b/applications/lfric_atm/optimisation/meto-ex1a/transmute/kernel/script_options.py
@@ -3,6 +3,9 @@
 # The file LICENCE, distributed with this code, contains details of the terms
 # under which the code may be used.
 # -----------------------------------------------------------------------------
+# Some of the content of this file has been produced with the assistance of
+# Anthropic Claude Opus 5 (Claude Code).
+# -----------------------------------------------------------------------------
 '''
 This file lifts optional overrides, where possible, into a localised,
 single location.
@@ -35,6 +38,7 @@ SCRIPT_OPTIONS_DICT["bl_exp_kernel_mod"+str(FILE_EXTEN)] = {
         "parcel_buoyancy", "qsat_at_lcl", "bl_type_ind", "visc_m_blend",
         "visc_h_blend", "zh_2d", "zhsc_2d", "ntml_2d", "cumulus_2d",
         "rh_crit", "mix_len_bm", "dsldzm", "wvar", "zht", "oblen",
+        "cape_undilute_2d",
         ]
 }
 

--- a/applications/lfric_atm/optimisation/ncas-ex/transmute/kernel/conv_gr_kernel_mod.py
+++ b/applications/lfric_atm/optimisation/ncas-ex/transmute/kernel/conv_gr_kernel_mod.py
@@ -3,6 +3,9 @@
 # The file LICENCE, distributed with this code, contains details of the terms
 # under which the code may be used.
 # -----------------------------------------------------------------------------
+# Some of the content of this file has been produced with the assistance of
+# Anthropic Claude Opus 5 (Claude Code).
+# -----------------------------------------------------------------------------
 """
 PSyclone script for applying OpenMP transformations specific to the
 Gregory-Rowntree convection kernel.
@@ -240,6 +243,7 @@ ignore_dependencies_block2_after_numseg = [
     "mid_dt",
     "mid_dq",
     "cca_unadjusted",
+    "ccw_unadjusted",
     "massflux_up_half",
     "du_conv",
     "dv_conv",

--- a/interfaces/physics_schemes_interface/source/algorithm/bl_exp_alg_mod.x90
+++ b/interfaces/physics_schemes_interface/source/algorithm/bl_exp_alg_mod.x90
@@ -3,6 +3,9 @@
 ! The file LICENCE, distributed with this code, contains details of the terms
 ! under which the code may be used.
 !-------------------------------------------------------------------------------
+! Some of the content of this file has been produced with the assistance of
+! Anthropic Claude Opus 5 (Claude Code).
+!-------------------------------------------------------------------------------
 !> @brief Interface to the explicit UM Boundary Layer scheme
 
 module bl_exp_alg_mod
@@ -217,7 +220,7 @@ contains
     type(mesh_type),           pointer :: mesh
     type( field_type ) :: dtl_mphys, dmt_mphys, ngstress_w2,                  &
                           fd_tau_w2, ngstress_bl, fd_taux, fd_tauy, fd_tauz,  &
-                          zht, oblen
+                          zht, oblen, cape_undilute
     type( field_type) :: rdz_wth, taux_land, tauy_land, taux_ssi, tauy_ssi
     type( field_type ) :: mr_ice
 
@@ -343,7 +346,7 @@ contains
     dz_wth           => get_dz_at_wtheta(config, mesh)
 
     ! Initialise diagnostics
-    call initialise_diags_for_bl_exp(zht, oblen)
+    call initialise_diags_for_bl_exp(zht, oblen, cape_undilute)
 
     ! Fields from microphysics
     call dtheta_mphys%copy_field_properties(dtl_mphys)
@@ -409,7 +412,8 @@ contains
                                     bl_weight_1dbl, bl_type_ind, level_ent,    &
                                     level_ent_dsc, ent_we_lim, ent_t_frac,     &
                                     ent_zrzi, ent_we_lim_dsc, ent_t_frac_dsc,  &
-                                    ent_zrzi_dsc, zht, oblen ),                &
+                                    ent_zrzi_dsc, zht, oblen,                  &
+                                    cape_undilute ),                           &
                 ! Initialise w2 fields
                 setval_c(rhokm_w2,       0.0_r_def),                           &
                 setval_c(surf_interp_w2, 0.0_r_def),                           &
@@ -478,7 +482,7 @@ contains
                                    ent_we_lim, ent_t_frac, ent_zrzi,         &
                                    ent_we_lim_dsc, ent_t_frac_dsc,           &
                                    ent_zrzi_dsc, zht, oblen,                 &
-                                   bl_weight_1dbl)
+                                   cape_undilute, bl_weight_1dbl)
 
     end if
 

--- a/interfaces/physics_schemes_interface/source/algorithm/conv_comorph_alg_mod.x90
+++ b/interfaces/physics_schemes_interface/source/algorithm/conv_comorph_alg_mod.x90
@@ -3,6 +3,9 @@
 ! The file LICENCE, distributed with this code, contains details of the terms
 ! under which the code may be used.
 !-------------------------------------------------------------------------------
+! Some of the content of this file has been produced with the assistance of
+! Anthropic Claude Opus 5 (Claude Code).
+!-------------------------------------------------------------------------------
 !> @brief Interface to the Comorph convection scheme
 
 module conv_comorph_alg_mod
@@ -270,6 +273,8 @@ contains
     type( field_type ) :: pres_cv_base,pres_cv_top
     type( field_type ) :: pres_lowest_cv_base, pres_lowest_cv_top, lowest_cca_2d
     type( field_type ) :: cloud_base_icao_height, cloud_top_icao_height
+    type( field_type ) :: lowest_cloud_base_icao_height
+    type( field_type ) :: lowest_cloud_top_icao_height
     type( field_type ) :: massflux_up_half
     type( field_type ) :: u_in_w3_latest, v_in_w3_latest, w_in_w3_latest, dw_conv
 
@@ -484,7 +489,9 @@ contains
                                       detrain_down,           &
                                       massflux_up_half,       &
                                       cloud_base_icao_height, &
-                                      cloud_top_icao_height)
+                                      cloud_top_icao_height,  &
+                                      lowest_cloud_base_icao_height, &
+                                      lowest_cloud_top_icao_height)
 
     ! call the scheme
     ncells = mesh%get_last_edge_cell()
@@ -692,7 +699,9 @@ contains
                                   detrain_down,           &
                                   massflux_up_half,       &
                                   cloud_base_icao_height, &
-                                  cloud_top_icao_height)
+                                  cloud_top_icao_height,  &
+                                  lowest_cloud_base_icao_height, &
+                                  lowest_cloud_top_icao_height)
 
     end if
 

--- a/interfaces/physics_schemes_interface/source/algorithm/conv_gr_alg_mod.x90
+++ b/interfaces/physics_schemes_interface/source/algorithm/conv_gr_alg_mod.x90
@@ -262,6 +262,7 @@ contains
 
     ! Local variables
     type( field_type ) :: cca_unadjusted
+    type( field_type ) :: ccw_unadjusted
     type( field_type ) :: deep_in_col, shallow_in_col, mid_in_col, deep_term
     type( field_type ) :: deep_prec, shallow_prec, mid_prec
     type( field_type ) :: freeze_level, cape_timescale
@@ -512,6 +513,7 @@ contains
                                    massflux_up_half,       &
                                    massflux_up_cmpta,      &
                                    cca_unadjusted,         &
+                                   ccw_unadjusted,         &
                                    dth_conv_noshal,        &
                                    dmv_conv_noshal,        &
                                    cloud_base_icao_height, &
@@ -727,7 +729,8 @@ contains
                           deep_tops,                                          &
                           massflux_up_half,                                   &
                           massflux_up_cmpta,                                  &
-                          cca_unadjusted, dth_conv_noshal, dmv_conv_noshal )  &
+                          cca_unadjusted, ccw_unadjusted,                     &
+                          dth_conv_noshal, dmv_conv_noshal )                  &
                           ) ! end of invoke
 
     ! Switch UM back to columns
@@ -802,6 +805,7 @@ contains
                                   massflux_up_half,      &
                                   massflux_up_cmpta,     &
                                   cca_unadjusted,        &
+                                  ccw_unadjusted,        &
                                   dth_conv_noshal,       &
                                   dmv_conv_noshal,       &
                                   cloud_base_icao_height,&

--- a/interfaces/physics_schemes_interface/source/algorithm/conv_gr_alg_mod.x90
+++ b/interfaces/physics_schemes_interface/source/algorithm/conv_gr_alg_mod.x90
@@ -3,6 +3,9 @@
 ! The file LICENCE, distributed with this code, contains details of the terms
 ! under which the code may be used.
 !-------------------------------------------------------------------------------
+! Some of the content of this file has been produced with the assistance of
+! Anthropic Claude Opus 5 (Claude Code).
+!-------------------------------------------------------------------------------
 !> @brief Interface to the UM Gregory Rowntree convection scheme
 
 module conv_gr_alg_mod
@@ -271,6 +274,8 @@ contains
     type( field_type ) :: pres_cv_base, pres_cv_top
     type( field_type ) :: pres_lowest_cv_base, pres_lowest_cv_top, lowest_cca_2d
     type( field_type ) :: cloud_base_icao_height, cloud_top_icao_height
+    type( field_type ) :: lowest_cloud_base_icao_height
+    type( field_type ) :: lowest_cloud_top_icao_height
     type( field_type ) :: deep_cfl_limited, mid_cfl_limited
     type( field_type ) :: massflux_up_half, massflux_up_cmpta
     type( field_type ) :: dth_conv_noshal, dmv_conv_noshal
@@ -510,7 +515,9 @@ contains
                                    dth_conv_noshal,        &
                                    dmv_conv_noshal,        &
                                    cloud_base_icao_height, &
-                                   cloud_top_icao_height)
+                                   cloud_top_icao_height,  &
+                                   lowest_cloud_base_icao_height, &
+                                   lowest_cloud_top_icao_height)
 
     ! Calculate total ice field
     call mr(imr_s)%copy_field_properties(mr_ice)
@@ -798,7 +805,9 @@ contains
                                   dth_conv_noshal,       &
                                   dmv_conv_noshal,       &
                                   cloud_base_icao_height,&
-                                  cloud_top_icao_height)
+                                  cloud_top_icao_height, &
+                                  lowest_cloud_base_icao_height, &
+                                  lowest_cloud_top_icao_height)
 
     end if
 

--- a/interfaces/physics_schemes_interface/source/diagnostics/bl_exp_diags_mod.f90
+++ b/interfaces/physics_schemes_interface/source/diagnostics/bl_exp_diags_mod.f90
@@ -3,6 +3,9 @@
 ! The file LICENCE, distributed with this code, contains details of the terms
 ! under which the code may be used.
 !-------------------------------------------------------------------------------
+! Some of the content of this file has been produced with the assistance of
+! Anthropic Claude Opus 5 (Claude Code).
+!-------------------------------------------------------------------------------
 !> @brief Processes diagnostics for bl_exp_alg
 
 module bl_exp_diags_mod
@@ -18,7 +21,7 @@ module bl_exp_diags_mod
   private
 
   ! Logical indicating whether diagnostics are requested
-  logical( l_def ) :: zht_flag, oblen_flag
+  logical( l_def ) :: zht_flag, oblen_flag, cape_undilute_flag
 
   public :: initialise_diags_for_bl_exp
   public :: output_diags_for_bl_exp
@@ -28,18 +31,21 @@ contains
   !> @brief Initialise fields for locally-computed diagnostics
   !> @param[inout] zht                Turbulent mixing height
   !> @param[inout] oblen              Obukhov length
-  subroutine initialise_diags_for_bl_exp(zht, oblen)
+  !> @param[inout] cape_undilute      CAPE from an undilute parcel ascent
+  subroutine initialise_diags_for_bl_exp(zht, oblen, cape_undilute)
 
     implicit none
 
     type( field_type ), intent(inout) :: zht
     type( field_type ), intent(inout) :: oblen
+    type( field_type ), intent(inout) :: cape_undilute
     integer( tik )                    :: id
 
     if ( LPROF ) call start_timing( id, 'diags.bl_exp' )
 
     zht_flag = init_diag(zht, 'turbulence__zht')
     oblen_flag = init_diag(oblen, 'turbulence__oblen')
+    cape_undilute_flag = init_diag(cape_undilute, 'convection__cape_undilute')
 
     if ( LPROF ) call stop_timing( id, 'diags.bl_exp' )
 
@@ -68,6 +74,7 @@ contains
   !> @param[in] ent_zrzi_dsc      Level height as fraction of DSC inversion height above DSC ML base
   !> @param[in] zht               Turbulent mixing height
   !> @param[in] oblen             Obukhov length
+  !> @param[in] cape_undilute     CAPE from an undilute parcel ascent
   !> @param[in] bl_weight_1dbl    Blending weight to 1D BL scheme in the BL
   subroutine output_diags_for_bl_exp(ntml, cumulus, bl_type_ind,               &
                                      wvar, dsldzm, mix_len_bm,                 &
@@ -76,7 +83,7 @@ contains
                                      ent_we_lim, ent_t_frac, ent_zrzi,         &
                                      ent_we_lim_dsc, ent_t_frac_dsc,           &
                                      ent_zrzi_dsc, zht, oblen,                 &
-                                     bl_weight_1dbl)
+                                     cape_undilute, bl_weight_1dbl)
 
     implicit none
 
@@ -87,7 +94,8 @@ contains
                                          zht,                                  &
                                          ent_we_lim, ent_t_frac, ent_zrzi,     &
                                          ent_we_lim_dsc, ent_t_frac_dsc,       &
-                                         ent_zrzi_dsc, oblen, bl_weight_1dbl
+                                         ent_zrzi_dsc, oblen, cape_undilute,   &
+                                         bl_weight_1dbl
     type(integer_field_type), intent(in) :: level_ent, level_ent_dsc, ntml,    &
                                             cumulus, bl_type_ind
     integer( tik )  :: id
@@ -120,6 +128,7 @@ contains
     ! Diagnostics computed in the kernel
     if (zht_flag) call zht%write_field()
     if (oblen_flag) call oblen%write_field()
+    if (cape_undilute_flag) call cape_undilute%write_field()
 
     if ( LPROF ) call stop_timing( id, 'diags.bl_exp' )
 

--- a/interfaces/physics_schemes_interface/source/diagnostics/comorph_diags_mod.x90
+++ b/interfaces/physics_schemes_interface/source/diagnostics/comorph_diags_mod.x90
@@ -3,6 +3,9 @@
 ! The file LICENCE, distributed with this code, contains details of the terms
 ! under which the code may be used.
 !-------------------------------------------------------------------------------
+! Some of the content of this file has been produced with the assistance of
+! Anthropic Claude Opus 5 (Claude Code).
+!-------------------------------------------------------------------------------
 !> @brief Processes diagnostics for comorph_alg
 
 module comorph_diags_mod
@@ -34,7 +37,9 @@ module comorph_diags_mod
                       detrain_down_flag,           &
                       massflux_up_half_flag,       &
                       cloud_base_icao_height_flag, &
-                      cloud_top_icao_height_flag
+                      cloud_top_icao_height_flag,  &
+                      lowest_cloud_base_icao_height_flag, &
+                      lowest_cloud_top_icao_height_flag
 
   public :: initialise_diags_for_comorph
   public :: output_diags_for_comorph
@@ -57,7 +62,9 @@ contains
                                           detrain_down,           &
                                           massflux_up_half,       &
                                           cloud_base_icao_height, &
-                                          cloud_top_icao_height)
+                                          cloud_top_icao_height,  &
+                                          lowest_cloud_base_icao_height, &
+                                          lowest_cloud_top_icao_height)
 
     implicit none
 
@@ -77,7 +84,9 @@ contains
                                          detrain_down,            &
                                          massflux_up_half,        &
                                          cloud_base_icao_height,  &
-                                         cloud_top_icao_height
+                                         cloud_top_icao_height,   &
+                                         lowest_cloud_base_icao_height, &
+                                         lowest_cloud_top_icao_height
     integer(tik)  :: id
 
     if ( LPROF ) call start_timing( id, 'diags.comorph' )
@@ -98,10 +107,19 @@ contains
     pres_cv_top_flag = init_diag(pres_cv_top, 'convection__pres_cv_top', &
       activate=cloud_top_icao_height_flag)
 
+    lowest_cloud_base_icao_height_flag = init_diag( &
+      lowest_cloud_base_icao_height, &
+      'convection__lowest_conv_cloud_base_icao_height')
+    lowest_cloud_top_icao_height_flag = init_diag( &
+      lowest_cloud_top_icao_height, &
+      'convection__lowest_conv_cloud_top_icao_height')
+
     pres_lowest_cv_base_flag = init_diag(pres_lowest_cv_base, &
-                                         'convection__pres_lowest_cv_base')
+      'convection__pres_lowest_cv_base', &
+      activate=lowest_cloud_base_icao_height_flag)
     pres_lowest_cv_top_flag = init_diag(pres_lowest_cv_top, &
-                                        'convection__pres_lowest_cv_top')
+      'convection__pres_lowest_cv_top', &
+      activate=lowest_cloud_top_icao_height_flag)
 
     lowest_cca_2d_flag = init_diag(lowest_cca_2d, &
                                    'convection__lowest_cca_2d')
@@ -160,7 +178,9 @@ contains
                                     detrain_down,           &
                                     massflux_up_half,       &
                                     cloud_base_icao_height, &
-                                    cloud_top_icao_height)
+                                    cloud_top_icao_height,  &
+                                    lowest_cloud_base_icao_height, &
+                                    lowest_cloud_top_icao_height)
 
     implicit none
 
@@ -202,7 +222,9 @@ contains
                                        detrain_down,           &
                                        massflux_up_half,       &
                                        cloud_base_icao_height, &
-                                       cloud_top_icao_height
+                                       cloud_top_icao_height,  &
+                                       lowest_cloud_base_icao_height, &
+                                       lowest_cloud_top_icao_height
     integer(tik)  :: id
 
     if ( LPROF ) call start_timing( id, 'diags.comorph' )
@@ -244,6 +266,18 @@ contains
       call invoke(icao_heights_kernel_type( &
         cloud_top_icao_height, pres_cv_top, g_over_r_def))
       call cloud_top_icao_height%write_field()
+    end if
+
+    if (lowest_cloud_base_icao_height_flag) then
+      call invoke(icao_heights_kernel_type( &
+        lowest_cloud_base_icao_height, pres_lowest_cv_base, g_over_r_def))
+      call lowest_cloud_base_icao_height%write_field()
+    end if
+
+    if (lowest_cloud_top_icao_height_flag) then
+      call invoke(icao_heights_kernel_type( &
+        lowest_cloud_top_icao_height, pres_lowest_cv_top, g_over_r_def))
+      call lowest_cloud_top_icao_height%write_field()
     end if
 
     ! Diagnostics computed within the kernel

--- a/interfaces/physics_schemes_interface/source/diagnostics/conv_diags_mod.x90
+++ b/interfaces/physics_schemes_interface/source/diagnostics/conv_diags_mod.x90
@@ -3,6 +3,9 @@
 ! The file LICENCE, distributed with this code, contains details of the terms
 ! under which the code may be used.
 !-------------------------------------------------------------------------------
+! Some of the content of this file has been produced with the assistance of
+! Anthropic Claude Opus 5 (Claude Code).
+!-------------------------------------------------------------------------------
 !> @brief Processes diagnostics for conv_alg
 
 module conv_diags_mod
@@ -60,7 +63,9 @@ module conv_diags_mod
                       dth_conv_noshal_flag,        &
                       dmv_conv_noshal_flag,        &
                       cloud_base_icao_height_flag, &
-                      cloud_top_icao_height_flag
+                      cloud_top_icao_height_flag,  &
+                      lowest_cloud_base_icao_height_flag, &
+                      lowest_cloud_top_icao_height_flag
 
   public :: initialise_diags_for_conv
   public :: output_diags_for_conv
@@ -112,7 +117,9 @@ contains
                                        dth_conv_noshal,        &
                                        dmv_conv_noshal,        &
                                        cloud_base_icao_height, &
-                                       cloud_top_icao_height)
+                                       cloud_top_icao_height,  &
+                                       lowest_cloud_base_icao_height, &
+                                       lowest_cloud_top_icao_height)
 
     implicit none
 
@@ -162,7 +169,9 @@ contains
                                          dth_conv_noshal,         &
                                          dmv_conv_noshal,         &
                                          cloud_base_icao_height,  &
-                                         cloud_top_icao_height
+                                         cloud_top_icao_height,   &
+                                         lowest_cloud_base_icao_height, &
+                                         lowest_cloud_top_icao_height
 
     logical(l_def) :: ignore
     integer(tik)   :: id
@@ -223,12 +232,24 @@ contains
       activate=cloud_top_icao_height_flag)
     ! not zeroed because overwritten
 
+    lowest_cloud_base_icao_height_flag = init_diag( &
+      lowest_cloud_base_icao_height, &
+      'convection__lowest_conv_cloud_base_icao_height')
+    ! not zeroed because overwritten
+
+    lowest_cloud_top_icao_height_flag = init_diag( &
+      lowest_cloud_top_icao_height, &
+      'convection__lowest_conv_cloud_top_icao_height')
+    ! not zeroed because overwritten
+
     pres_lowest_cv_base_flag = init_diag(pres_lowest_cv_base, &
-                                         'convection__pres_lowest_cv_base')
+      'convection__pres_lowest_cv_base', &
+      activate=lowest_cloud_base_icao_height_flag)
     ! not zeroed because overwritten
 
     pres_lowest_cv_top_flag = init_diag(pres_lowest_cv_top, &
-                                        'convection__pres_lowest_cv_top')
+      'convection__pres_lowest_cv_top', &
+      activate=lowest_cloud_top_icao_height_flag)
     ! not zeroed because overwritten
 
     lowest_cca_2d_flag = init_diag(lowest_cca_2d, &
@@ -385,7 +406,9 @@ contains
                                     dth_conv_noshal,        &
                                     dmv_conv_noshal,        &
                                     cloud_base_icao_height, &
-                                    cloud_top_icao_height)
+                                    cloud_top_icao_height,  &
+                                    lowest_cloud_base_icao_height, &
+                                    lowest_cloud_top_icao_height)
 
     implicit none
 
@@ -454,7 +477,9 @@ contains
                                        dth_conv_noshal,        &
                                        dmv_conv_noshal,        &
                                        cloud_base_icao_height, &
-                                       cloud_top_icao_height
+                                       cloud_top_icao_height,  &
+                                       lowest_cloud_base_icao_height, &
+                                       lowest_cloud_top_icao_height
     integer( tik )  :: id
 
     if ( LPROF ) call start_timing( id, 'diags.conv' )
@@ -496,6 +521,18 @@ contains
       call invoke(icao_heights_kernel_type( &
         cloud_top_icao_height, pres_cv_top, g_over_r_def))
       call cloud_top_icao_height%write_field()
+    end if
+
+    if (lowest_cloud_base_icao_height_flag) then
+      call invoke(icao_heights_kernel_type( &
+        lowest_cloud_base_icao_height, pres_lowest_cv_base, g_over_r_def))
+      call lowest_cloud_base_icao_height%write_field()
+    end if
+
+    if (lowest_cloud_top_icao_height_flag) then
+      call invoke(icao_heights_kernel_type( &
+        lowest_cloud_top_icao_height, pres_lowest_cv_top, g_over_r_def))
+      call lowest_cloud_top_icao_height%write_field()
     end if
 
     ! Diagnostics computed within the kernel

--- a/interfaces/physics_schemes_interface/source/diagnostics/conv_diags_mod.x90
+++ b/interfaces/physics_schemes_interface/source/diagnostics/conv_diags_mod.x90
@@ -60,6 +60,7 @@ module conv_diags_mod
                       massflux_up_half_flag,       &
                       massflux_up_cmpta_flag,      &
                       cca_unadjusted_flag,         &
+                      ccw_unadjusted_flag,         &
                       dth_conv_noshal_flag,        &
                       dmv_conv_noshal_flag,        &
                       cloud_base_icao_height_flag, &
@@ -114,6 +115,7 @@ contains
                                        massflux_up_half,       &
                                        massflux_up_cmpta,      &
                                        cca_unadjusted,         &
+                                       ccw_unadjusted,         &
                                        dth_conv_noshal,        &
                                        dmv_conv_noshal,        &
                                        cloud_base_icao_height, &
@@ -166,6 +168,7 @@ contains
                                          massflux_up_half,        &
                                          massflux_up_cmpta,       &
                                          cca_unadjusted,          &
+                                         ccw_unadjusted,          &
                                          dth_conv_noshal,         &
                                          dmv_conv_noshal,         &
                                          cloud_base_icao_height,  &
@@ -322,6 +325,9 @@ contains
     cca_unadjusted_flag = init_diag(cca_unadjusted, 'convection__cca_unadjusted')
     if (cca_unadjusted_flag) call invoke( setval_c(cca_unadjusted, 0.0_r_def) )
 
+    ccw_unadjusted_flag = init_diag(ccw_unadjusted, 'convection__ccw_unadjusted')
+    if (ccw_unadjusted_flag) call invoke( setval_c(ccw_unadjusted, 0.0_r_def) )
+
     dth_conv_noshal_flag = init_diag(dth_conv_noshal, 'convection__dth_conv_noshal')
 
     dmv_conv_noshal_flag = init_diag(dmv_conv_noshal, 'convection__dmv_conv_noshal')
@@ -403,6 +409,7 @@ contains
                                     massflux_up_half,       &
                                     massflux_up_cmpta,      &
                                     cca_unadjusted,         &
+                                    ccw_unadjusted,         &
                                     dth_conv_noshal,        &
                                     dmv_conv_noshal,        &
                                     cloud_base_icao_height, &
@@ -474,6 +481,7 @@ contains
                                        massflux_up_half,       &
                                        massflux_up_cmpta,      &
                                        cca_unadjusted,         &
+                                       ccw_unadjusted,         &
                                        dth_conv_noshal,        &
                                        dmv_conv_noshal,        &
                                        cloud_base_icao_height, &
@@ -577,6 +585,7 @@ contains
     if (massflux_up_half_flag) call massflux_up_half%write_field()
     if (massflux_up_cmpta_flag) call massflux_up_cmpta%write_field()
     if (cca_unadjusted_flag) call cca_unadjusted%write_field()
+    if (ccw_unadjusted_flag) call ccw_unadjusted%write_field()
     if (dth_conv_noshal_flag) call dth_conv_noshal%write_field()
     if (dmv_conv_noshal_flag) call dmv_conv_noshal%write_field()
 

--- a/interfaces/physics_schemes_interface/source/kernel/bl_exp_kernel_mod.F90
+++ b/interfaces/physics_schemes_interface/source/kernel/bl_exp_kernel_mod.F90
@@ -3,6 +3,9 @@
 ! The file LICENCE, distributed with this code, contains details of the terms
 ! under which the code may be used.
 !-----------------------------------------------------------------------------
+! Some of the content of this file has been produced with the assistance of
+! Anthropic Claude Opus 5 (Claude Code).
+!-----------------------------------------------------------------------------
 !> @brief Interface to the explicit UM boundary layer scheme.
 module bl_exp_kernel_mod
 
@@ -40,7 +43,7 @@ module bl_exp_kernel_mod
   !>
   type, public, extends(kernel_type) :: bl_exp_kernel_type
     private
-    type(arg_type) :: meta_args(93) = (/                                       &
+    type(arg_type) :: meta_args(94) = (/                                       &
          arg_type(GH_FIELD, GH_REAL,  GH_READ,      WTHETA),                   &! theta_in_wth
          arg_type(GH_FIELD, GH_REAL,  GH_READ,      W3),                       &! rho_in_w3
          arg_type(GH_FIELD, GH_REAL,  GH_READ,      WTHETA),                   &! rho_in_wth
@@ -133,7 +136,8 @@ module bl_exp_kernel_mod
          arg_type(GH_FIELD, GH_REAL,  GH_WRITE,     ANY_DISCONTINUOUS_SPACE_5),&! ent_t_frac_dsc
          arg_type(GH_FIELD, GH_REAL,  GH_WRITE,     ANY_DISCONTINUOUS_SPACE_5),&! ent_zrzi_dsc
          arg_type(GH_FIELD, GH_REAL,  GH_WRITE,     ANY_DISCONTINUOUS_SPACE_1),&! diag__zht
-         arg_type(GH_FIELD, GH_REAL,  GH_WRITE,     ANY_DISCONTINUOUS_SPACE_1) &! diag__oblen
+         arg_type(GH_FIELD, GH_REAL,  GH_WRITE,     ANY_DISCONTINUOUS_SPACE_1),&! diag__oblen
+         arg_type(GH_FIELD, GH_REAL,  GH_WRITE,     ANY_DISCONTINUOUS_SPACE_1) &! diag__cape_undilute
          /)
     integer :: operates_on = DOMAIN
   contains
@@ -242,6 +246,8 @@ contains
   !> @param[in,out] ent_zrzi_dsc           Level height as fraction of DSC inversion height above DSC ML base
   !> @param[in,out] zht                    Diagnostic: turb mixing height
   !> @param[in,out] oblen                  Diagnostic: Obukhov length
+  !> @param[in,out] cape_undilute_2d       Diagnostic: CAPE from an undilute
+  !>                                       parcel ascent
   !> @param[in]     ndf_wth                Number of DOFs per cell for potential temperature space
   !> @param[in]     undf_wth               Number of unique DOFs for potential temperature space
   !> @param[in]     map_wth                Dofmap for the cell at the base of the column for potential temperature space
@@ -357,6 +363,7 @@ contains
                          ent_zrzi_dsc,                          &
                          zht,                                   &
                          oblen,                                 &
+                         cape_undilute_2d,                      &
                          ndf_wth, undf_wth, map_wth,            &
                          ndf_w3, undf_w3, map_w3,               &
                          ndf_2d, undf_2d, map_2d,               &
@@ -501,6 +508,7 @@ contains
 
     real(kind=r_def), pointer, intent(inout) :: zht(:)
     real(kind=r_def), pointer, intent(inout) :: oblen(:)
+    real(kind=r_def), pointer, intent(inout) :: cape_undilute_2d(:)
     !-----------------------------------------------------------------------
     ! Local variables for the kernel
     !-----------------------------------------------------------------------
@@ -1160,6 +1168,11 @@ contains
     if (.not. associated(oblen, empty_real_data) ) then
       do i = 1, seg_len
         oblen(map_2d(1,i)) = BL_diag%oblen(i,1)
+      end do
+    end if
+    if (.not. associated(cape_undilute_2d, empty_real_data) ) then
+      do i = 1, seg_len
+        cape_undilute_2d(map_2d(1,i)) = real(cape_undilute(i,1), r_def)
       end do
     end if
 

--- a/interfaces/physics_schemes_interface/source/kernel/conv_gr_kernel_mod.F90
+++ b/interfaces/physics_schemes_interface/source/kernel/conv_gr_kernel_mod.F90
@@ -3,6 +3,9 @@
 ! The file LICENCE, distributed with this code, contains details of the terms
 ! under which the code may be used.
 !-----------------------------------------------------------------------------
+! Some of the content of this file has been produced with the assistance of
+! Anthropic Claude Opus 5 (Claude Code).
+!-----------------------------------------------------------------------------
 !> @brief Interface to the UM Gregory Rowntree Convection scheme.
 !>
 module conv_gr_kernel_mod
@@ -34,7 +37,7 @@ module conv_gr_kernel_mod
   !>
   type, public, extends(kernel_type) :: conv_gr_kernel_type
     private
-    type(arg_type) :: meta_args(210) = (/                                         &
+    type(arg_type) :: meta_args(211) = (/                                         &
          arg_type(GH_SCALAR, GH_INTEGER, GH_READ),                                &! outer
          arg_type(GH_FIELD,  GH_REAL,    GH_READ,      W3),                       &! rho_in_w3
          arg_type(GH_FIELD,  GH_REAL,    GH_READ,      WTHETA),                   &! rho_in_wth
@@ -243,6 +246,7 @@ module conv_gr_kernel_mod
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! massflux_up_half
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! massflux_up_cmpta
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! cca_unadjusted
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! ccw_unadjusted
          arg_type(GH_FIELD,  GH_REAL,    GH_WRITE,     WTHETA),                   &! dth_conv_noshal
          arg_type(GH_FIELD,  GH_REAL,    GH_WRITE,     WTHETA)                    &! dmv_conv_noshal
         /)
@@ -469,6 +473,7 @@ contains
   !> @param[in,out] massflux_up_half     Convective upwards mass flux on half-levels (Pa/s)
   !> @param[in,out] massflux_up_cmpta    Convective upwards mass flux component A (Pa/s)
   !> @param[in,out] cca_unadjusted       Convective cloud amout unadjusted for radiation calc.
+  !> @param[in,out] ccw_unadjusted       Convective cloud water unadjusted for radiation calc.
   !> @param[out]    dth_conv_noshal      Convection theta increment from non-shallow regions
   !> @param[out]    dmv_conv_noshal      Convection vapour increment from non-shallow regions
   !> @param[in]     ndf_w3               Number of DOFs per cell for density space
@@ -693,6 +698,7 @@ contains
                           massflux_up_half,                  &
                           massflux_up_cmpta,                 &
                           cca_unadjusted,                    &
+                          ccw_unadjusted,                    &
                           dth_conv_noshal,                   &
                           dmv_conv_noshal,                   &
                           ndf_w3,                            &
@@ -1071,6 +1077,7 @@ contains
                                                 massflux_up_half(:), &
                                                 massflux_up_cmpta(:),&
                                                 cca_unadjusted(:),   &
+                                                ccw_unadjusted(:),   &
                                                 dth_conv_noshal(:),  &
                                                 dmv_conv_noshal(:)
 
@@ -2516,6 +2523,14 @@ contains
             do i = 1, ncells
               cca_unadjusted(map_wth(1,i) + k) = cca_unadjusted(map_wth(1,i) + k) +  &
                                            it_cca(i,1,k)*one_over_conv_calls
+            end do
+          end do
+        end if
+        if (.not. associated(ccw_unadjusted, empty_real_data) ) then
+          do k = 1, n_conv_levels
+            do i = 1, ncells
+              ccw_unadjusted(map_wth(1,i) + k) = ccw_unadjusted(map_wth(1,i) + k) +  &
+                                           it_ccw(i,1,k)*one_over_conv_calls
             end do
           end do
         end if

--- a/rose-stem/app/lfric_atm/file/file_def_diags_oper_nwp_gl.xml
+++ b/rose-stem/app/lfric_atm/file/file_def_diags_oper_nwp_gl.xml
@@ -148,7 +148,9 @@
       <field field_ref="aviation__geopot_thickness_500"/>
       <field field_ref="convection__conv_cloud_base_icao_height"/>
       <field field_ref="convection__conv_cloud_top_icao_height"/>
-    </field_group>     
+      <field field_ref="convection__lowest_conv_cloud_base_icao_height"/>
+      <field field_ref="convection__lowest_conv_cloud_top_icao_height"/>
+    </field_group>
     
     <field_group operation="average" freq_op="3h" prec="4">  
       <field field_ref="surface__soil_surf_ht_flux" name="soil_surf_ht_flux_average"/>

--- a/rose-stem/app/lfric_atm/file/file_def_diags_oper_nwp_gl.xml
+++ b/rose-stem/app/lfric_atm/file/file_def_diags_oper_nwp_gl.xml
@@ -150,6 +150,7 @@
       <field field_ref="convection__conv_cloud_top_icao_height"/>
       <field field_ref="convection__lowest_conv_cloud_base_icao_height"/>
       <field field_ref="convection__lowest_conv_cloud_top_icao_height"/>
+      <field field_ref="convection__cape_undilute"/>
     </field_group>
     
     <field_group operation="average" freq_op="3h" prec="4">  

--- a/rose-stem/app/lfric_atm/file/file_def_diags_oper_nwp_gl.xml
+++ b/rose-stem/app/lfric_atm/file/file_def_diags_oper_nwp_gl.xml
@@ -150,7 +150,6 @@
       <field field_ref="convection__conv_cloud_top_icao_height"/>
       <field field_ref="convection__lowest_conv_cloud_base_icao_height"/>
       <field field_ref="convection__lowest_conv_cloud_top_icao_height"/>
-      <field field_ref="convection__cape_undilute"/>
     </field_group>
     
     <field_group operation="average" freq_op="3h" prec="4">  

--- a/rose-stem/app/lfric_coupled_atmosphere/file/iodef_basic_gal.xml
+++ b/rose-stem/app/lfric_coupled_atmosphere/file/iodef_basic_gal.xml
@@ -333,6 +333,7 @@
 	<field id="convection__mid_in_col" name="mid_in_col" long_name="frequency_of_midlevel_convection" unit="1" domain_ref="face" />
 	<field id="convection__mid_cfl_limited" name="mid_cfl_limited" long_name="midlevel_convection_cfl_limited" unit="1" domain_ref="face" />
 	<field id="convection__cape_diluted" name="cape_diluted" long_name="cape_diluted" unit="J/kg" domain_ref="face" />
+	<field id="convection__cape_undilute" name="cape_undilute" long_name="cape_from_undilute_parcel_ascent" unit="J/kg" domain_ref="face" />
 	<field id="convection__cape_timescale" name="cape_timescale" long_name="cape_timescale" unit="s" domain_ref="face" />
 	<field id="convection__freeze_level" name="freeze_level" long_name="model_level_number_at_freezing_level" unit="1" domain_ref="face" />
 	<field id="convection__lowest_cv_base" name="lowest_cv_base" long_name="model_level_number_at_lowest_conv_cloud_base" unit="1" domain_ref="face" />

--- a/rose-stem/app/lfric_coupled_atmosphere/file/iodef_basic_gal.xml
+++ b/rose-stem/app/lfric_coupled_atmosphere/file/iodef_basic_gal.xml
@@ -333,7 +333,6 @@
 	<field id="convection__mid_in_col" name="mid_in_col" long_name="frequency_of_midlevel_convection" unit="1" domain_ref="face" />
 	<field id="convection__mid_cfl_limited" name="mid_cfl_limited" long_name="midlevel_convection_cfl_limited" unit="1" domain_ref="face" />
 	<field id="convection__cape_diluted" name="cape_diluted" long_name="cape_diluted" unit="J/kg" domain_ref="face" />
-	<field id="convection__cape_undilute" name="cape_undilute" long_name="cape_from_undilute_parcel_ascent" unit="J/kg" domain_ref="face" />
 	<field id="convection__cape_timescale" name="cape_timescale" long_name="cape_timescale" unit="s" domain_ref="face" />
 	<field id="convection__freeze_level" name="freeze_level" long_name="model_level_number_at_freezing_level" unit="1" domain_ref="face" />
 	<field id="convection__lowest_cv_base" name="lowest_cv_base" long_name="model_level_number_at_lowest_conv_cloud_base" unit="1" domain_ref="face" />


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: @MichaelWhitall 
Code Reviewer: @EdHone 

<!-- To be completed by the developer -->

| UM stashcode | LFRic ID |
| --- | --- |
| 5-224 | lowest_conv_cloud_base_icao_height |
| 5-225 | lowest_conv_cloud_top_icao_height |
| 5-233 | cape_undilute |
| 5-213 | ccw_unscaled |

Some plots of the new diagnostics:
<img width="761" height="765" alt="Screenshot from 2026-07-30 09-17-41" src="https://github.com/user-attachments/assets/c03d32a9-820f-4fc7-9ce5-fccdd30cd57b" />
<img width="749" height="770" alt="Screenshot from 2026-07-30 09-17-19" src="https://github.com/user-attachments/assets/068c9552-5d4f-4229-a324-2526bf284847" />
<img width="723" height="655" alt="Screenshot from 2026-07-29 16-27-32" src="https://github.com/user-attachments/assets/75708200-fbbe-4f8e-b81e-c1b88dc99a85" />
<img width="712" height="657" alt="Screenshot from 2026-08-10 15-35-01" src="https://github.com/user-attachments/assets/c43d79aa-6c01-44ad-abe4-3f9ee12a6310" />


<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

closes #643 

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] I have tested this change locally, using the LFRic Apps rose-stem suite
- [x] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [x] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

# Test Suite Results - lfric_apps - conv_icao_cape_diags/run1

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [conv_icao_cape_diags/run1](https://cylchub/services/cylc-review/cycles/ian.boutle/?suite=conv_icao_cape_diags%2Frun1) |
| Suite User | ian.boutle |
| Workflow Start | 2026-07-29T15:29:43 |
| Groups Run | developer', 'lfric_atm_nwp_gal9_oper-C224_MG_ex1a_cce_production-32bit |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| casim | [MetOffice/casim@2026.07.1](https://github.com/MetOffice/casim/tree/2026.07.1) | True |
| jules | [MetOffice/jules@2026.07.1](https://github.com/MetOffice/jules/tree/2026.07.1) | True |
| lfric_apps | [iboutle/lfric_apps@conv_icao_cape_diags](https://github.com/iboutle/lfric_apps/tree/conv_icao_cape_diags) | False |
| lfric_core | [MetOffice/lfric_core@2026.07.1](https://github.com/MetOffice/lfric_core/tree/2026.07.1) | True |
| moci | [MetOffice/moci@2026.07.1](https://github.com/MetOffice/moci/tree/2026.07.1) | True |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@2026.07.1](https://github.com/MetOffice/SimSys_Scripts/tree/2026.07.1) | True |
| socrates | [MetOffice/socrates@2026.07.1](https://github.com/MetOffice/socrates/tree/2026.07.1) | True |
| socrates-spectral | [MetOffice/socrates-spectral@2026.07.1](https://github.com/MetOffice/socrates-spectral/tree/2026.07.1) | True |
| ukca | [MetOffice/ukca@2026.07.1](https://github.com/MetOffice/ukca/tree/2026.07.1) | True |

## Task Information
:white_check_mark: succeeded tasks - 1221


## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [x] Sensitive data is properly handled (if applicable)
- [x] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [x] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [x] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
