### PR TITLE
Comorph diagnostics

### DIFF
--- a/applications/lfric_atm/metadata/field_def_diags.xml
+++ b/applications/lfric_atm/metadata/field_def_diags.xml
@@ -414,6 +414,23 @@
   <field id="convection__turb_pert_t" name="turb_pert_t" long_name="convection_turbulent_temperature_perturbation" unit="K" grid_ref="half_level_face_grid" />
   <field id="convection__turb_pert_q" name="turb_pert_q" long_name="convection_turbulent_water_vapour_perturbation" unit="kg kg-1" grid_ref="half_level_face_grid" />
   <field id="convection__turb_radius" name="turb_radius" long_name="convection_turbulent_parcel_radius" unit="m" grid_ref="full_level_face_grid" />
+  <field id="convection__subreg_dry_frac" name="subreg_dry_frac" long_name="convection_clear_sky_subregion_fraction" unit="1" grid_ref="full_level_face_grid" />
+  <field id="convection__subreg_liq_frac" name="subreg_liq_frac" long_name="convection_liquid_cloud_subregion_fraction" unit="1" grid_ref="full_level_face_grid" />
+  <field id="convection__subreg_mph_frac" name="subreg_mph_frac" long_name="convection_mixed_phase_subregion_fraction" unit="1" grid_ref="full_level_face_grid" />
+  <field id="convection__subreg_icr_frac" name="subreg_icr_frac" long_name="convection_ice_rain_subregion_fraction" unit="1" grid_ref="full_level_face_grid" />
+  <field id="convection__subreg_dry_t" name="subreg_dry_t" long_name="convection_clear_sky_subregion_temperature" unit="K" grid_ref="full_level_face_grid" />
+  <field id="convection__subreg_liq_t" name="subreg_liq_t" long_name="convection_liquid_cloud_subregion_temperature" unit="K" grid_ref="full_level_face_grid" />
+  <field id="convection__subreg_mph_t" name="subreg_mph_t" long_name="convection_mixed_phase_subregion_temperature" unit="K" grid_ref="full_level_face_grid" />
+  <field id="convection__subreg_icr_t" name="subreg_icr_t" long_name="convection_ice_rain_subregion_temperature" unit="K" grid_ref="full_level_face_grid" />
+  <field id="convection__subreg_dry_q" name="subreg_dry_q" long_name="convection_clear_sky_subregion_water_vapour" unit="kg kg-1" grid_ref="full_level_face_grid" />
+  <field id="convection__subreg_liq_q" name="subreg_liq_q" long_name="convection_liquid_cloud_subregion_water_vapour" unit="kg kg-1" grid_ref="full_level_face_grid" />
+  <field id="convection__subreg_mph_q" name="subreg_mph_q" long_name="convection_mixed_phase_subregion_water_vapour" unit="kg kg-1" grid_ref="full_level_face_grid" />
+  <field id="convection__subreg_icr_q" name="subreg_icr_q" long_name="convection_ice_rain_subregion_water_vapour" unit="kg kg-1" grid_ref="full_level_face_grid" />
+  <field id="convection__subreg_dry_rhl" name="subreg_dry_rhl" long_name="convection_clear_sky_subregion_relative_humidity_wrt_liquid" unit="1" grid_ref="full_level_face_grid" />
+  <field id="convection__subreg_liq_rhl" name="subreg_liq_rhl" long_name="convection_liquid_cloud_subregion_relative_humidity_wrt_liquid" unit="1" grid_ref="full_level_face_grid" />
+  <field id="convection__subreg_mph_rhl" name="subreg_mph_rhl" long_name="convection_mixed_phase_subregion_relative_humidity_wrt_liquid" unit="1" grid_ref="full_level_face_grid" />
+  <field id="convection__subreg_icr_rhl" name="subreg_icr_rhl" long_name="convection_ice_rain_subregion_relative_humidity_wrt_liquid" unit="1" grid_ref="full_level_face_grid" />
+  <field id="convection__massflux_down_half" name="massflux_down_half" long_name="conv_downward_massflux_half_levs" unit="Pa s-1" grid_ref="half_level_face_grid" />
   <field id="convection__dd_dt" name="dd_dt" long_name="temperature_increment_from_downdraughts" unit="K s-1" grid_ref="full_level_face_grid" />
   <field id="convection__dd_dq" name="dd_dq" long_name="water_vapour_increment_from_downdraughts" unit="kg kg-1 s-1" grid_ref="full_level_face_grid" />
   <field id="convection__conv_rain" name="conv_rain" long_name="surface_convective_rainfall_rate" unit="kg m-2 s-1" domain_ref="face" />

--- a/applications/lfric_atm/metadata/field_def_diags.xml
+++ b/applications/lfric_atm/metadata/field_def_diags.xml
@@ -374,6 +374,36 @@
   <field id="convection__par_radius_down" name="par_radius_down" long_name="convection_downdraught_parcel_radius" unit="m" grid_ref="half_level_face_grid" />
   <field id="convection__freq_up" name="freq_up" long_name="convection_updraught_frequency" unit="1" grid_ref="half_level_face_grid" />
   <field id="convection__freq_down" name="freq_down" long_name="convection_downdraught_frequency" unit="1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_dtv_up" name="par_mean_dtv_up" long_name="convection_updraught_parcel_mean_excess_virtual_temperature" unit="K" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_dtv_down" name="par_mean_dtv_down" long_name="convection_downdraught_parcel_mean_excess_virtual_temperature" unit="K" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_rhl_up" name="par_mean_rhl_up" long_name="convection_updraught_parcel_mean_relative_humidity_wrt_liquid" unit="1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_rhl_down" name="par_mean_rhl_down" long_name="convection_downdraught_parcel_mean_relative_humidity_wrt_liquid" unit="1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_q_up" name="par_mean_q_up" long_name="convection_updraught_parcel_mean_water_vapour" unit="kg kg-1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_q_down" name="par_mean_q_down" long_name="convection_downdraught_parcel_mean_water_vapour" unit="kg kg-1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_qcl_up" name="par_mean_qcl_up" long_name="convection_updraught_parcel_mean_liquid_water" unit="kg kg-1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_qcl_down" name="par_mean_qcl_down" long_name="convection_downdraught_parcel_mean_liquid_water" unit="kg kg-1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_qcf_up" name="par_mean_qcf_up" long_name="convection_updraught_parcel_mean_ice_water" unit="kg kg-1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_qcf_down" name="par_mean_qcf_down" long_name="convection_downdraught_parcel_mean_ice_water" unit="kg kg-1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_qrain_up" name="par_mean_qrain_up" long_name="convection_updraught_parcel_mean_rain" unit="kg kg-1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_qrain_down" name="par_mean_qrain_down" long_name="convection_downdraught_parcel_mean_rain" unit="kg kg-1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_qgraup_up" name="par_mean_qgraup_up" long_name="convection_updraught_parcel_mean_graupel" unit="kg kg-1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_qgraup_down" name="par_mean_qgraup_down" long_name="convection_downdraught_parcel_mean_graupel" unit="kg kg-1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_qsnow_up" name="par_mean_qsnow_up" long_name="convection_updraught_parcel_mean_snow" unit="kg kg-1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_qsnow_down" name="par_mean_qsnow_down" long_name="convection_downdraught_parcel_mean_snow" unit="kg kg-1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_cfl_up" name="par_mean_cfl_up" long_name="convection_updraught_parcel_mean_liquid_cloud_fraction" unit="1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_cfl_down" name="par_mean_cfl_down" long_name="convection_downdraught_parcel_mean_liquid_cloud_fraction" unit="1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_cff_up" name="par_mean_cff_up" long_name="convection_updraught_parcel_mean_ice_cloud_fraction" unit="1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_cff_down" name="par_mean_cff_down" long_name="convection_downdraught_parcel_mean_ice_cloud_fraction" unit="1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_cfb_up" name="par_mean_cfb_up" long_name="convection_updraught_parcel_mean_bulk_cloud_fraction" unit="1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_cfb_down" name="par_mean_cfb_down" long_name="convection_downdraught_parcel_mean_bulk_cloud_fraction" unit="1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_u_up" name="par_mean_u_up" long_name="convection_updraught_parcel_mean_u_wind" unit="m s-1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_u_down" name="par_mean_u_down" long_name="convection_downdraught_parcel_mean_u_wind" unit="m s-1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_v_up" name="par_mean_v_up" long_name="convection_updraught_parcel_mean_v_wind" unit="m s-1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_v_down" name="par_mean_v_down" long_name="convection_downdraught_parcel_mean_v_wind" unit="m s-1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_w_up" name="par_mean_w_up" long_name="convection_updraught_parcel_mean_w_wind" unit="m s-1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_w_down" name="par_mean_w_down" long_name="convection_downdraught_parcel_mean_w_wind" unit="m s-1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_t_up" name="par_mean_t_up" long_name="convection_updraught_parcel_mean_temperature" unit="K" grid_ref="half_level_face_grid" />
+  <field id="convection__par_mean_t_down" name="par_mean_t_down" long_name="convection_downdraught_parcel_mean_temperature" unit="K" grid_ref="half_level_face_grid" />
   <field id="convection__dd_dt" name="dd_dt" long_name="temperature_increment_from_downdraughts" unit="K s-1" grid_ref="full_level_face_grid" />
   <field id="convection__dd_dq" name="dd_dq" long_name="water_vapour_increment_from_downdraughts" unit="kg kg-1 s-1" grid_ref="full_level_face_grid" />
   <field id="convection__conv_rain" name="conv_rain" long_name="surface_convective_rainfall_rate" unit="kg m-2 s-1" domain_ref="face" />

--- a/applications/lfric_atm/metadata/field_def_diags.xml
+++ b/applications/lfric_atm/metadata/field_def_diags.xml
@@ -372,6 +372,8 @@
   <field id="convection__detrain_down" name="detrain_down" long_name="convection_downward_detrain" unit="1" grid_ref="full_level_face_grid" />
   <field id="convection__par_radius_up" name="par_radius_up" long_name="convection_updraught_parcel_radius" unit="m" grid_ref="half_level_face_grid" />
   <field id="convection__par_radius_down" name="par_radius_down" long_name="convection_downdraught_parcel_radius" unit="m" grid_ref="half_level_face_grid" />
+  <field id="convection__freq_up" name="freq_up" long_name="convection_updraught_frequency" unit="1" grid_ref="half_level_face_grid" />
+  <field id="convection__freq_down" name="freq_down" long_name="convection_downdraught_frequency" unit="1" grid_ref="half_level_face_grid" />
   <field id="convection__dd_dt" name="dd_dt" long_name="temperature_increment_from_downdraughts" unit="K s-1" grid_ref="full_level_face_grid" />
   <field id="convection__dd_dq" name="dd_dq" long_name="water_vapour_increment_from_downdraughts" unit="kg kg-1 s-1" grid_ref="full_level_face_grid" />
   <field id="convection__conv_rain" name="conv_rain" long_name="surface_convective_rainfall_rate" unit="kg m-2 s-1" domain_ref="face" />

--- a/applications/lfric_atm/metadata/field_def_diags.xml
+++ b/applications/lfric_atm/metadata/field_def_diags.xml
@@ -408,6 +408,12 @@
   <field id="convection__par_core_dtv_down" name="par_core_dtv_down" long_name="convection_downdraught_parcel_core_excess_virtual_temperature" unit="K" grid_ref="half_level_face_grid" />
   <field id="convection__par_core_rhl_up" name="par_core_rhl_up" long_name="convection_updraught_parcel_core_relative_humidity_wrt_liquid" unit="1" grid_ref="half_level_face_grid" />
   <field id="convection__par_core_rhl_down" name="par_core_rhl_down" long_name="convection_downdraught_parcel_core_relative_humidity_wrt_liquid" unit="1" grid_ref="half_level_face_grid" />
+  <field id="convection__turb_pert_u" name="turb_pert_u" long_name="convection_turbulent_u_wind_perturbation" unit="m s-1" grid_ref="half_level_face_grid" />
+  <field id="convection__turb_pert_v" name="turb_pert_v" long_name="convection_turbulent_v_wind_perturbation" unit="m s-1" grid_ref="half_level_face_grid" />
+  <field id="convection__turb_pert_w" name="turb_pert_w" long_name="convection_turbulent_w_wind_perturbation" unit="m s-1" grid_ref="half_level_face_grid" />
+  <field id="convection__turb_pert_t" name="turb_pert_t" long_name="convection_turbulent_temperature_perturbation" unit="K" grid_ref="half_level_face_grid" />
+  <field id="convection__turb_pert_q" name="turb_pert_q" long_name="convection_turbulent_water_vapour_perturbation" unit="kg kg-1" grid_ref="half_level_face_grid" />
+  <field id="convection__turb_radius" name="turb_radius" long_name="convection_turbulent_parcel_radius" unit="m" grid_ref="full_level_face_grid" />
   <field id="convection__dd_dt" name="dd_dt" long_name="temperature_increment_from_downdraughts" unit="K s-1" grid_ref="full_level_face_grid" />
   <field id="convection__dd_dq" name="dd_dq" long_name="water_vapour_increment_from_downdraughts" unit="kg kg-1 s-1" grid_ref="full_level_face_grid" />
   <field id="convection__conv_rain" name="conv_rain" long_name="surface_convective_rainfall_rate" unit="kg m-2 s-1" domain_ref="face" />

--- a/applications/lfric_atm/metadata/field_def_diags.xml
+++ b/applications/lfric_atm/metadata/field_def_diags.xml
@@ -370,6 +370,8 @@
   <field id="convection__entrain_down" name="entrain_down" long_name="convection_downward_entrain" unit="1" grid_ref="full_level_face_grid" />
   <field id="convection__detrain_up" name="detrain_up" long_name="convection_upward_detrain" unit="1" grid_ref="full_level_face_grid" />
   <field id="convection__detrain_down" name="detrain_down" long_name="convection_downward_detrain" unit="1" grid_ref="full_level_face_grid" />
+  <field id="convection__par_radius_up" name="par_radius_up" long_name="convection_updraught_parcel_radius" unit="m" grid_ref="half_level_face_grid" />
+  <field id="convection__par_radius_down" name="par_radius_down" long_name="convection_downdraught_parcel_radius" unit="m" grid_ref="half_level_face_grid" />
   <field id="convection__dd_dt" name="dd_dt" long_name="temperature_increment_from_downdraughts" unit="K s-1" grid_ref="full_level_face_grid" />
   <field id="convection__dd_dq" name="dd_dq" long_name="water_vapour_increment_from_downdraughts" unit="kg kg-1 s-1" grid_ref="full_level_face_grid" />
   <field id="convection__conv_rain" name="conv_rain" long_name="surface_convective_rainfall_rate" unit="kg m-2 s-1" domain_ref="face" />

--- a/applications/lfric_atm/metadata/field_def_diags.xml
+++ b/applications/lfric_atm/metadata/field_def_diags.xml
@@ -404,6 +404,10 @@
   <field id="convection__par_mean_w_down" name="par_mean_w_down" long_name="convection_downdraught_parcel_mean_w_wind" unit="m s-1" grid_ref="half_level_face_grid" />
   <field id="convection__par_mean_t_up" name="par_mean_t_up" long_name="convection_updraught_parcel_mean_temperature" unit="K" grid_ref="half_level_face_grid" />
   <field id="convection__par_mean_t_down" name="par_mean_t_down" long_name="convection_downdraught_parcel_mean_temperature" unit="K" grid_ref="half_level_face_grid" />
+  <field id="convection__par_core_dtv_up" name="par_core_dtv_up" long_name="convection_updraught_parcel_core_excess_virtual_temperature" unit="K" grid_ref="half_level_face_grid" />
+  <field id="convection__par_core_dtv_down" name="par_core_dtv_down" long_name="convection_downdraught_parcel_core_excess_virtual_temperature" unit="K" grid_ref="half_level_face_grid" />
+  <field id="convection__par_core_rhl_up" name="par_core_rhl_up" long_name="convection_updraught_parcel_core_relative_humidity_wrt_liquid" unit="1" grid_ref="half_level_face_grid" />
+  <field id="convection__par_core_rhl_down" name="par_core_rhl_down" long_name="convection_downdraught_parcel_core_relative_humidity_wrt_liquid" unit="1" grid_ref="half_level_face_grid" />
   <field id="convection__dd_dt" name="dd_dt" long_name="temperature_increment_from_downdraughts" unit="K s-1" grid_ref="full_level_face_grid" />
   <field id="convection__dd_dq" name="dd_dq" long_name="water_vapour_increment_from_downdraughts" unit="kg kg-1 s-1" grid_ref="full_level_face_grid" />
   <field id="convection__conv_rain" name="conv_rain" long_name="surface_convective_rainfall_rate" unit="kg m-2 s-1" domain_ref="face" />

--- a/interfaces/physics_schemes_interface/source/algorithm/conv_comorph_alg_mod.x90
+++ b/interfaces/physics_schemes_interface/source/algorithm/conv_comorph_alg_mod.x90
@@ -294,6 +294,12 @@ contains
     type( field_type ) :: par_core_rhl_up,par_core_rhl_down
     type( field_type ) :: turb_pert_u,turb_pert_v,turb_pert_w
     type( field_type ) :: turb_pert_t,turb_pert_q,turb_radius
+    type( field_type ) :: subreg_dry_frac,subreg_liq_frac,subreg_mph_frac
+    type( field_type ) :: subreg_icr_frac,subreg_dry_t,subreg_liq_t
+    type( field_type ) :: subreg_mph_t,subreg_icr_t,subreg_dry_q
+    type( field_type ) :: subreg_liq_q,subreg_mph_q,subreg_icr_q
+    type( field_type ) :: subreg_dry_rhl,subreg_liq_rhl,subreg_mph_rhl
+    type( field_type ) :: subreg_icr_rhl,massflux_down_half
     type( field_type ) :: u_in_w3_latest, v_in_w3_latest, w_in_w3_latest, dw_conv
 
     type( mesh_type ), pointer  :: mesh
@@ -549,7 +555,24 @@ contains
                                       turb_pert_w,          &
                                       turb_pert_t,          &
                                       turb_pert_q,          &
-                                      turb_radius)
+                                      turb_radius,          &
+                                      subreg_dry_frac,      &
+                                      subreg_liq_frac,      &
+                                      subreg_mph_frac,      &
+                                      subreg_icr_frac,      &
+                                      subreg_dry_t,         &
+                                      subreg_liq_t,         &
+                                      subreg_mph_t,         &
+                                      subreg_icr_t,         &
+                                      subreg_dry_q,         &
+                                      subreg_liq_q,         &
+                                      subreg_mph_q,         &
+                                      subreg_icr_q,         &
+                                      subreg_dry_rhl,       &
+                                      subreg_liq_rhl,       &
+                                      subreg_mph_rhl,       &
+                                      subreg_icr_rhl,       &
+                                      massflux_down_half)
 
     ! call the scheme
     ncells = mesh%get_last_edge_cell()
@@ -751,7 +774,24 @@ contains
                           turb_pert_w,                                        &
                           turb_pert_t,                                        &
                           turb_pert_q,                                        &
-                          turb_radius)                                        &
+                          turb_radius,                                        &
+                          subreg_dry_frac,                                    &
+                          subreg_liq_frac,                                    &
+                          subreg_mph_frac,                                    &
+                          subreg_icr_frac,                                    &
+                          subreg_dry_t,                                       &
+                          subreg_liq_t,                                       &
+                          subreg_mph_t,                                       &
+                          subreg_icr_t,                                       &
+                          subreg_dry_q,                                       &
+                          subreg_liq_q,                                       &
+                          subreg_mph_q,                                       &
+                          subreg_icr_q,                                       &
+                          subreg_dry_rhl,                                     &
+                          subreg_liq_rhl,                                     &
+                          subreg_mph_rhl,                                     &
+                          subreg_icr_rhl,                                     &
+                          massflux_down_half)                                 &
                                            ) ! end of invoke
 
     call um_sizes_init(1_i_def)
@@ -843,7 +883,24 @@ contains
                                   turb_pert_w,           &
                                   turb_pert_t,           &
                                   turb_pert_q,           &
-                                  turb_radius)
+                                  turb_radius,           &
+                                  subreg_dry_frac,       &
+                                  subreg_liq_frac,       &
+                                  subreg_mph_frac,       &
+                                  subreg_icr_frac,       &
+                                  subreg_dry_t,          &
+                                  subreg_liq_t,          &
+                                  subreg_mph_t,          &
+                                  subreg_icr_t,          &
+                                  subreg_dry_q,          &
+                                  subreg_liq_q,          &
+                                  subreg_mph_q,          &
+                                  subreg_icr_q,          &
+                                  subreg_dry_rhl,        &
+                                  subreg_liq_rhl,        &
+                                  subreg_mph_rhl,        &
+                                  subreg_icr_rhl,        &
+                                  massflux_down_half)
 
     end if
 

--- a/interfaces/physics_schemes_interface/source/algorithm/conv_comorph_alg_mod.x90
+++ b/interfaces/physics_schemes_interface/source/algorithm/conv_comorph_alg_mod.x90
@@ -274,6 +274,7 @@ contains
     type( field_type ) :: pres_lowest_cv_base,pres_lowest_cv_top, lowest_cca_2d
     type( field_type ) :: massflux_up_half
     type( field_type ) :: par_radius_up,par_radius_down
+    type( field_type ) :: freq_up,freq_down
     type( field_type ) :: u_in_w3_latest, v_in_w3_latest, w_in_w3_latest, dw_conv
 
     type( mesh_type ), pointer  :: mesh
@@ -487,7 +488,9 @@ contains
                                       detrain_down,         &
                                       massflux_up_half,     &
                                       par_radius_up,        &
-                                      par_radius_down)
+                                      par_radius_down,      &
+                                      freq_up,              &
+                                      freq_down)
 
     ! call the scheme
     ncells = mesh%get_last_edge_cell()
@@ -647,7 +650,9 @@ contains
                           detrain_down,                                       &
                           massflux_up_half,                                   &
                           par_radius_up,                                      &
-                          par_radius_down)                                    &
+                          par_radius_down,                                    &
+                          freq_up,                                            &
+                          freq_down)                                          &
                                            ) ! end of invoke
 
     call um_sizes_init(1_i_def)
@@ -697,7 +702,9 @@ contains
                                   detrain_down,          &
                                   massflux_up_half,      &
                                   par_radius_up,         &
-                                  par_radius_down)
+                                  par_radius_down,       &
+                                  freq_up,               &
+                                  freq_down)
 
     end if
 

--- a/interfaces/physics_schemes_interface/source/algorithm/conv_comorph_alg_mod.x90
+++ b/interfaces/physics_schemes_interface/source/algorithm/conv_comorph_alg_mod.x90
@@ -290,6 +290,8 @@ contains
     type( field_type ) :: par_mean_v_up,par_mean_v_down
     type( field_type ) :: par_mean_w_up,par_mean_w_down
     type( field_type ) :: par_mean_t_up,par_mean_t_down
+    type( field_type ) :: par_core_dtv_up,par_core_dtv_down
+    type( field_type ) :: par_core_rhl_up,par_core_rhl_down
     type( field_type ) :: u_in_w3_latest, v_in_w3_latest, w_in_w3_latest, dw_conv
 
     type( mesh_type ), pointer  :: mesh
@@ -535,7 +537,11 @@ contains
                                       par_mean_w_up,        &
                                       par_mean_w_down,      &
                                       par_mean_t_up,        &
-                                      par_mean_t_down)
+                                      par_mean_t_down,      &
+                                      par_core_dtv_up,      &
+                                      par_core_dtv_down,    &
+                                      par_core_rhl_up,      &
+                                      par_core_rhl_down)
 
     ! call the scheme
     ncells = mesh%get_last_edge_cell()
@@ -727,7 +733,11 @@ contains
                           par_mean_w_up,                                      &
                           par_mean_w_down,                                    &
                           par_mean_t_up,                                      &
-                          par_mean_t_down)                                    &
+                          par_mean_t_down,                                    &
+                          par_core_dtv_up,                                    &
+                          par_core_dtv_down,                                  &
+                          par_core_rhl_up,                                    &
+                          par_core_rhl_down)                                  &
                                            ) ! end of invoke
 
     call um_sizes_init(1_i_def)
@@ -809,7 +819,11 @@ contains
                                   par_mean_w_up,         &
                                   par_mean_w_down,       &
                                   par_mean_t_up,         &
-                                  par_mean_t_down)
+                                  par_mean_t_down,       &
+                                  par_core_dtv_up,       &
+                                  par_core_dtv_down,     &
+                                  par_core_rhl_up,       &
+                                  par_core_rhl_down)
 
     end if
 

--- a/interfaces/physics_schemes_interface/source/algorithm/conv_comorph_alg_mod.x90
+++ b/interfaces/physics_schemes_interface/source/algorithm/conv_comorph_alg_mod.x90
@@ -275,6 +275,21 @@ contains
     type( field_type ) :: massflux_up_half
     type( field_type ) :: par_radius_up,par_radius_down
     type( field_type ) :: freq_up,freq_down
+    type( field_type ) :: par_mean_dtv_up,par_mean_dtv_down
+    type( field_type ) :: par_mean_rhl_up,par_mean_rhl_down
+    type( field_type ) :: par_mean_q_up,par_mean_q_down
+    type( field_type ) :: par_mean_qcl_up,par_mean_qcl_down
+    type( field_type ) :: par_mean_qcf_up,par_mean_qcf_down
+    type( field_type ) :: par_mean_qrain_up,par_mean_qrain_down
+    type( field_type ) :: par_mean_qgraup_up,par_mean_qgraup_down
+    type( field_type ) :: par_mean_qsnow_up,par_mean_qsnow_down
+    type( field_type ) :: par_mean_cfl_up,par_mean_cfl_down
+    type( field_type ) :: par_mean_cff_up,par_mean_cff_down
+    type( field_type ) :: par_mean_cfb_up,par_mean_cfb_down
+    type( field_type ) :: par_mean_u_up,par_mean_u_down
+    type( field_type ) :: par_mean_v_up,par_mean_v_down
+    type( field_type ) :: par_mean_w_up,par_mean_w_down
+    type( field_type ) :: par_mean_t_up,par_mean_t_down
     type( field_type ) :: u_in_w3_latest, v_in_w3_latest, w_in_w3_latest, dw_conv
 
     type( mesh_type ), pointer  :: mesh
@@ -490,7 +505,37 @@ contains
                                       par_radius_up,        &
                                       par_radius_down,      &
                                       freq_up,              &
-                                      freq_down)
+                                      freq_down,            &
+                                      par_mean_dtv_up,      &
+                                      par_mean_dtv_down,    &
+                                      par_mean_rhl_up,      &
+                                      par_mean_rhl_down,    &
+                                      par_mean_q_up,        &
+                                      par_mean_q_down,      &
+                                      par_mean_qcl_up,      &
+                                      par_mean_qcl_down,    &
+                                      par_mean_qcf_up,      &
+                                      par_mean_qcf_down,    &
+                                      par_mean_qrain_up,    &
+                                      par_mean_qrain_down,  &
+                                      par_mean_qgraup_up,   &
+                                      par_mean_qgraup_down, &
+                                      par_mean_qsnow_up,    &
+                                      par_mean_qsnow_down,  &
+                                      par_mean_cfl_up,      &
+                                      par_mean_cfl_down,    &
+                                      par_mean_cff_up,      &
+                                      par_mean_cff_down,    &
+                                      par_mean_cfb_up,      &
+                                      par_mean_cfb_down,    &
+                                      par_mean_u_up,        &
+                                      par_mean_u_down,      &
+                                      par_mean_v_up,        &
+                                      par_mean_v_down,      &
+                                      par_mean_w_up,        &
+                                      par_mean_w_down,      &
+                                      par_mean_t_up,        &
+                                      par_mean_t_down)
 
     ! call the scheme
     ncells = mesh%get_last_edge_cell()
@@ -652,7 +697,37 @@ contains
                           par_radius_up,                                      &
                           par_radius_down,                                    &
                           freq_up,                                            &
-                          freq_down)                                          &
+                          freq_down,                                          &
+                          par_mean_dtv_up,                                    &
+                          par_mean_dtv_down,                                  &
+                          par_mean_rhl_up,                                    &
+                          par_mean_rhl_down,                                  &
+                          par_mean_q_up,                                      &
+                          par_mean_q_down,                                    &
+                          par_mean_qcl_up,                                    &
+                          par_mean_qcl_down,                                  &
+                          par_mean_qcf_up,                                    &
+                          par_mean_qcf_down,                                  &
+                          par_mean_qrain_up,                                  &
+                          par_mean_qrain_down,                                &
+                          par_mean_qgraup_up,                                 &
+                          par_mean_qgraup_down,                               &
+                          par_mean_qsnow_up,                                  &
+                          par_mean_qsnow_down,                                &
+                          par_mean_cfl_up,                                    &
+                          par_mean_cfl_down,                                  &
+                          par_mean_cff_up,                                    &
+                          par_mean_cff_down,                                  &
+                          par_mean_cfb_up,                                    &
+                          par_mean_cfb_down,                                  &
+                          par_mean_u_up,                                      &
+                          par_mean_u_down,                                    &
+                          par_mean_v_up,                                      &
+                          par_mean_v_down,                                    &
+                          par_mean_w_up,                                      &
+                          par_mean_w_down,                                    &
+                          par_mean_t_up,                                      &
+                          par_mean_t_down)                                    &
                                            ) ! end of invoke
 
     call um_sizes_init(1_i_def)
@@ -704,7 +779,37 @@ contains
                                   par_radius_up,         &
                                   par_radius_down,       &
                                   freq_up,               &
-                                  freq_down)
+                                  freq_down,             &
+                                  par_mean_dtv_up,       &
+                                  par_mean_dtv_down,     &
+                                  par_mean_rhl_up,       &
+                                  par_mean_rhl_down,     &
+                                  par_mean_q_up,         &
+                                  par_mean_q_down,       &
+                                  par_mean_qcl_up,       &
+                                  par_mean_qcl_down,     &
+                                  par_mean_qcf_up,       &
+                                  par_mean_qcf_down,     &
+                                  par_mean_qrain_up,     &
+                                  par_mean_qrain_down,   &
+                                  par_mean_qgraup_up,    &
+                                  par_mean_qgraup_down,  &
+                                  par_mean_qsnow_up,     &
+                                  par_mean_qsnow_down,   &
+                                  par_mean_cfl_up,       &
+                                  par_mean_cfl_down,     &
+                                  par_mean_cff_up,       &
+                                  par_mean_cff_down,     &
+                                  par_mean_cfb_up,       &
+                                  par_mean_cfb_down,     &
+                                  par_mean_u_up,         &
+                                  par_mean_u_down,       &
+                                  par_mean_v_up,         &
+                                  par_mean_v_down,       &
+                                  par_mean_w_up,         &
+                                  par_mean_w_down,       &
+                                  par_mean_t_up,         &
+                                  par_mean_t_down)
 
     end if
 

--- a/interfaces/physics_schemes_interface/source/algorithm/conv_comorph_alg_mod.x90
+++ b/interfaces/physics_schemes_interface/source/algorithm/conv_comorph_alg_mod.x90
@@ -292,6 +292,8 @@ contains
     type( field_type ) :: par_mean_t_up,par_mean_t_down
     type( field_type ) :: par_core_dtv_up,par_core_dtv_down
     type( field_type ) :: par_core_rhl_up,par_core_rhl_down
+    type( field_type ) :: turb_pert_u,turb_pert_v,turb_pert_w
+    type( field_type ) :: turb_pert_t,turb_pert_q,turb_radius
     type( field_type ) :: u_in_w3_latest, v_in_w3_latest, w_in_w3_latest, dw_conv
 
     type( mesh_type ), pointer  :: mesh
@@ -541,7 +543,13 @@ contains
                                       par_core_dtv_up,      &
                                       par_core_dtv_down,    &
                                       par_core_rhl_up,      &
-                                      par_core_rhl_down)
+                                      par_core_rhl_down,    &
+                                      turb_pert_u,          &
+                                      turb_pert_v,          &
+                                      turb_pert_w,          &
+                                      turb_pert_t,          &
+                                      turb_pert_q,          &
+                                      turb_radius)
 
     ! call the scheme
     ncells = mesh%get_last_edge_cell()
@@ -737,7 +745,13 @@ contains
                           par_core_dtv_up,                                    &
                           par_core_dtv_down,                                  &
                           par_core_rhl_up,                                    &
-                          par_core_rhl_down)                                  &
+                          par_core_rhl_down,                                  &
+                          turb_pert_u,                                        &
+                          turb_pert_v,                                        &
+                          turb_pert_w,                                        &
+                          turb_pert_t,                                        &
+                          turb_pert_q,                                        &
+                          turb_radius)                                        &
                                            ) ! end of invoke
 
     call um_sizes_init(1_i_def)
@@ -823,7 +837,13 @@ contains
                                   par_core_dtv_up,       &
                                   par_core_dtv_down,     &
                                   par_core_rhl_up,       &
-                                  par_core_rhl_down)
+                                  par_core_rhl_down,     &
+                                  turb_pert_u,           &
+                                  turb_pert_v,           &
+                                  turb_pert_w,           &
+                                  turb_pert_t,           &
+                                  turb_pert_q,           &
+                                  turb_radius)
 
     end if
 

--- a/interfaces/physics_schemes_interface/source/algorithm/conv_comorph_alg_mod.x90
+++ b/interfaces/physics_schemes_interface/source/algorithm/conv_comorph_alg_mod.x90
@@ -3,6 +3,9 @@
 ! The file LICENCE, distributed with this code, contains details of the terms
 ! under which the code may be used.
 !-------------------------------------------------------------------------------
+! Some of the content of this file has been produced with the assistance of
+! Anthropic Claude Opus 5 (Claude Code).
+!-------------------------------------------------------------------------------
 !> @brief Interface to the Comorph convection scheme
 
 module conv_comorph_alg_mod
@@ -270,6 +273,7 @@ contains
     type( field_type ) :: pres_cv_base,pres_cv_top
     type( field_type ) :: pres_lowest_cv_base,pres_lowest_cv_top, lowest_cca_2d
     type( field_type ) :: massflux_up_half
+    type( field_type ) :: par_radius_up,par_radius_down
     type( field_type ) :: u_in_w3_latest, v_in_w3_latest, w_in_w3_latest, dw_conv
 
     type( mesh_type ), pointer  :: mesh
@@ -481,7 +485,9 @@ contains
                                       entrain_down,         &
                                       detrain_up,           &
                                       detrain_down,         &
-                                      massflux_up_half)
+                                      massflux_up_half,     &
+                                      par_radius_up,        &
+                                      par_radius_down)
 
     ! call the scheme
     ncells = mesh%get_last_edge_cell()
@@ -639,7 +645,9 @@ contains
                           entrain_down,                                       &
                           detrain_up,                                         &
                           detrain_down,                                       &
-                          massflux_up_half)                                   &
+                          massflux_up_half,                                   &
+                          par_radius_up,                                      &
+                          par_radius_down)                                    &
                                            ) ! end of invoke
 
     call um_sizes_init(1_i_def)
@@ -687,7 +695,9 @@ contains
                                   entrain_down,          &
                                   detrain_up,            &
                                   detrain_down,          &
-                                  massflux_up_half)
+                                  massflux_up_half,      &
+                                  par_radius_up,         &
+                                  par_radius_down)
 
     end if
 

--- a/interfaces/physics_schemes_interface/source/diagnostics/comorph_diags_mod.x90
+++ b/interfaces/physics_schemes_interface/source/diagnostics/comorph_diags_mod.x90
@@ -36,7 +36,37 @@ module comorph_diags_mod
                       par_radius_up_flag,          &
                       par_radius_down_flag,        &
                       freq_up_flag,                &
-                      freq_down_flag
+                      freq_down_flag,              &
+                      par_mean_dtv_up_flag,        &
+                      par_mean_dtv_down_flag,      &
+                      par_mean_rhl_up_flag,        &
+                      par_mean_rhl_down_flag,      &
+                      par_mean_q_up_flag,          &
+                      par_mean_q_down_flag,        &
+                      par_mean_qcl_up_flag,        &
+                      par_mean_qcl_down_flag,      &
+                      par_mean_qcf_up_flag,        &
+                      par_mean_qcf_down_flag,      &
+                      par_mean_qrain_up_flag,      &
+                      par_mean_qrain_down_flag,    &
+                      par_mean_qgraup_up_flag,     &
+                      par_mean_qgraup_down_flag,   &
+                      par_mean_qsnow_up_flag,      &
+                      par_mean_qsnow_down_flag,    &
+                      par_mean_cfl_up_flag,        &
+                      par_mean_cfl_down_flag,      &
+                      par_mean_cff_up_flag,        &
+                      par_mean_cff_down_flag,      &
+                      par_mean_cfb_up_flag,        &
+                      par_mean_cfb_down_flag,      &
+                      par_mean_u_up_flag,          &
+                      par_mean_u_down_flag,        &
+                      par_mean_v_up_flag,          &
+                      par_mean_v_down_flag,        &
+                      par_mean_w_up_flag,          &
+                      par_mean_w_down_flag,        &
+                      par_mean_t_up_flag,          &
+                      par_mean_t_down_flag
 
   public :: initialise_diags_for_comorph
   public :: output_diags_for_comorph
@@ -61,7 +91,37 @@ contains
                                           par_radius_up,          &
                                           par_radius_down,        &
                                           freq_up,                &
-                                          freq_down)
+                                          freq_down,              &
+                                          par_mean_dtv_up,        &
+                                          par_mean_dtv_down,      &
+                                          par_mean_rhl_up,        &
+                                          par_mean_rhl_down,      &
+                                          par_mean_q_up,          &
+                                          par_mean_q_down,        &
+                                          par_mean_qcl_up,        &
+                                          par_mean_qcl_down,      &
+                                          par_mean_qcf_up,        &
+                                          par_mean_qcf_down,      &
+                                          par_mean_qrain_up,      &
+                                          par_mean_qrain_down,    &
+                                          par_mean_qgraup_up,     &
+                                          par_mean_qgraup_down,   &
+                                          par_mean_qsnow_up,      &
+                                          par_mean_qsnow_down,    &
+                                          par_mean_cfl_up,        &
+                                          par_mean_cfl_down,      &
+                                          par_mean_cff_up,        &
+                                          par_mean_cff_down,      &
+                                          par_mean_cfb_up,        &
+                                          par_mean_cfb_down,      &
+                                          par_mean_u_up,          &
+                                          par_mean_u_down,        &
+                                          par_mean_v_up,          &
+                                          par_mean_v_down,        &
+                                          par_mean_w_up,          &
+                                          par_mean_w_down,        &
+                                          par_mean_t_up,          &
+                                          par_mean_t_down)
 
     implicit none
 
@@ -83,7 +143,37 @@ contains
                                          par_radius_up,           &
                                          par_radius_down,         &
                                          freq_up,                 &
-                                         freq_down
+                                         freq_down,               &
+                                         par_mean_dtv_up,         &
+                                         par_mean_dtv_down,       &
+                                         par_mean_rhl_up,         &
+                                         par_mean_rhl_down,       &
+                                         par_mean_q_up,           &
+                                         par_mean_q_down,         &
+                                         par_mean_qcl_up,         &
+                                         par_mean_qcl_down,       &
+                                         par_mean_qcf_up,         &
+                                         par_mean_qcf_down,       &
+                                         par_mean_qrain_up,       &
+                                         par_mean_qrain_down,     &
+                                         par_mean_qgraup_up,      &
+                                         par_mean_qgraup_down,    &
+                                         par_mean_qsnow_up,       &
+                                         par_mean_qsnow_down,     &
+                                         par_mean_cfl_up,         &
+                                         par_mean_cfl_down,       &
+                                         par_mean_cff_up,         &
+                                         par_mean_cff_down,       &
+                                         par_mean_cfb_up,         &
+                                         par_mean_cfb_down,       &
+                                         par_mean_u_up,           &
+                                         par_mean_u_down,         &
+                                         par_mean_v_up,           &
+                                         par_mean_v_down,         &
+                                         par_mean_w_up,           &
+                                         par_mean_w_down,         &
+                                         par_mean_t_up,           &
+                                         par_mean_t_down
     integer(tik)  :: id
 
     if ( LPROF ) call start_timing( id, 'diags.comorph' )
@@ -135,6 +225,146 @@ contains
     freq_down_flag = init_diag(freq_down, 'convection__freq_down')
     if (freq_down_flag) call invoke( setval_c(freq_down, 0.0_r_def) )
 
+    par_mean_dtv_up_flag = init_diag(par_mean_dtv_up,                         &
+                                     'convection__par_mean_dtv_up')
+    if (par_mean_dtv_up_flag) call invoke( setval_c(par_mean_dtv_up,          &
+                                                    0.0_r_def) )
+
+    par_mean_dtv_down_flag = init_diag(par_mean_dtv_down,                     &
+                                       'convection__par_mean_dtv_down')
+    if (par_mean_dtv_down_flag) call invoke( setval_c(par_mean_dtv_down,      &
+                                                      0.0_r_def) )
+
+    par_mean_rhl_up_flag = init_diag(par_mean_rhl_up,                         &
+                                     'convection__par_mean_rhl_up')
+    if (par_mean_rhl_up_flag) call invoke( setval_c(par_mean_rhl_up,          &
+                                                    0.0_r_def) )
+
+    par_mean_rhl_down_flag = init_diag(par_mean_rhl_down,                     &
+                                       'convection__par_mean_rhl_down')
+    if (par_mean_rhl_down_flag) call invoke( setval_c(par_mean_rhl_down,      &
+                                                      0.0_r_def) )
+
+    par_mean_q_up_flag = init_diag(par_mean_q_up, 'convection__par_mean_q_up')
+    if (par_mean_q_up_flag) call invoke( setval_c(par_mean_q_up, 0.0_r_def) )
+
+    par_mean_q_down_flag = init_diag(par_mean_q_down,                         &
+                                     'convection__par_mean_q_down')
+    if (par_mean_q_down_flag) call invoke( setval_c(par_mean_q_down,          &
+                                                    0.0_r_def) )
+
+    par_mean_qcl_up_flag = init_diag(par_mean_qcl_up,                         &
+                                     'convection__par_mean_qcl_up')
+    if (par_mean_qcl_up_flag) call invoke( setval_c(par_mean_qcl_up,          &
+                                                    0.0_r_def) )
+
+    par_mean_qcl_down_flag = init_diag(par_mean_qcl_down,                     &
+                                       'convection__par_mean_qcl_down')
+    if (par_mean_qcl_down_flag) call invoke( setval_c(par_mean_qcl_down,      &
+                                                      0.0_r_def) )
+
+    par_mean_qcf_up_flag = init_diag(par_mean_qcf_up,                         &
+                                     'convection__par_mean_qcf_up')
+    if (par_mean_qcf_up_flag) call invoke( setval_c(par_mean_qcf_up,          &
+                                                    0.0_r_def) )
+
+    par_mean_qcf_down_flag = init_diag(par_mean_qcf_down,                     &
+                                       'convection__par_mean_qcf_down')
+    if (par_mean_qcf_down_flag) call invoke( setval_c(par_mean_qcf_down,      &
+                                                      0.0_r_def) )
+
+    par_mean_qrain_up_flag = init_diag(par_mean_qrain_up,                     &
+                                       'convection__par_mean_qrain_up')
+    if (par_mean_qrain_up_flag) call invoke( setval_c(par_mean_qrain_up,      &
+                                                      0.0_r_def) )
+
+    par_mean_qrain_down_flag = init_diag(par_mean_qrain_down,                 &
+                                         'convection__par_mean_qrain_down')
+    if (par_mean_qrain_down_flag) call invoke( setval_c(par_mean_qrain_down,  &
+                                                        0.0_r_def) )
+
+    par_mean_qgraup_up_flag = init_diag(par_mean_qgraup_up,                   &
+                                        'convection__par_mean_qgraup_up')
+    if (par_mean_qgraup_up_flag) call invoke( setval_c(par_mean_qgraup_up,    &
+                                                       0.0_r_def) )
+
+    par_mean_qgraup_down_flag = init_diag(par_mean_qgraup_down,               &
+                                          'convection__par_mean_qgraup_down')
+    if (par_mean_qgraup_down_flag) call invoke( setval_c(par_mean_qgraup_down,&
+                                                         0.0_r_def) )
+
+    par_mean_qsnow_up_flag = init_diag(par_mean_qsnow_up,                     &
+                                       'convection__par_mean_qsnow_up')
+    if (par_mean_qsnow_up_flag) call invoke( setval_c(par_mean_qsnow_up,      &
+                                                      0.0_r_def) )
+
+    par_mean_qsnow_down_flag = init_diag(par_mean_qsnow_down,                 &
+                                         'convection__par_mean_qsnow_down')
+    if (par_mean_qsnow_down_flag) call invoke( setval_c(par_mean_qsnow_down,  &
+                                                        0.0_r_def) )
+
+    par_mean_cfl_up_flag = init_diag(par_mean_cfl_up,                         &
+                                     'convection__par_mean_cfl_up')
+    if (par_mean_cfl_up_flag) call invoke( setval_c(par_mean_cfl_up,          &
+                                                    0.0_r_def) )
+
+    par_mean_cfl_down_flag = init_diag(par_mean_cfl_down,                     &
+                                       'convection__par_mean_cfl_down')
+    if (par_mean_cfl_down_flag) call invoke( setval_c(par_mean_cfl_down,      &
+                                                      0.0_r_def) )
+
+    par_mean_cff_up_flag = init_diag(par_mean_cff_up,                         &
+                                     'convection__par_mean_cff_up')
+    if (par_mean_cff_up_flag) call invoke( setval_c(par_mean_cff_up,          &
+                                                    0.0_r_def) )
+
+    par_mean_cff_down_flag = init_diag(par_mean_cff_down,                     &
+                                       'convection__par_mean_cff_down')
+    if (par_mean_cff_down_flag) call invoke( setval_c(par_mean_cff_down,      &
+                                                      0.0_r_def) )
+
+    par_mean_cfb_up_flag = init_diag(par_mean_cfb_up,                         &
+                                     'convection__par_mean_cfb_up')
+    if (par_mean_cfb_up_flag) call invoke( setval_c(par_mean_cfb_up,          &
+                                                    0.0_r_def) )
+
+    par_mean_cfb_down_flag = init_diag(par_mean_cfb_down,                     &
+                                       'convection__par_mean_cfb_down')
+    if (par_mean_cfb_down_flag) call invoke( setval_c(par_mean_cfb_down,      &
+                                                      0.0_r_def) )
+
+    par_mean_u_up_flag = init_diag(par_mean_u_up, 'convection__par_mean_u_up')
+    if (par_mean_u_up_flag) call invoke( setval_c(par_mean_u_up, 0.0_r_def) )
+
+    par_mean_u_down_flag = init_diag(par_mean_u_down,                         &
+                                     'convection__par_mean_u_down')
+    if (par_mean_u_down_flag) call invoke( setval_c(par_mean_u_down,          &
+                                                    0.0_r_def) )
+
+    par_mean_v_up_flag = init_diag(par_mean_v_up, 'convection__par_mean_v_up')
+    if (par_mean_v_up_flag) call invoke( setval_c(par_mean_v_up, 0.0_r_def) )
+
+    par_mean_v_down_flag = init_diag(par_mean_v_down,                         &
+                                     'convection__par_mean_v_down')
+    if (par_mean_v_down_flag) call invoke( setval_c(par_mean_v_down,          &
+                                                    0.0_r_def) )
+
+    par_mean_w_up_flag = init_diag(par_mean_w_up, 'convection__par_mean_w_up')
+    if (par_mean_w_up_flag) call invoke( setval_c(par_mean_w_up, 0.0_r_def) )
+
+    par_mean_w_down_flag = init_diag(par_mean_w_down,                         &
+                                     'convection__par_mean_w_down')
+    if (par_mean_w_down_flag) call invoke( setval_c(par_mean_w_down,          &
+                                                    0.0_r_def) )
+
+    par_mean_t_up_flag = init_diag(par_mean_t_up, 'convection__par_mean_t_up')
+    if (par_mean_t_up_flag) call invoke( setval_c(par_mean_t_up, 0.0_r_def) )
+
+    par_mean_t_down_flag = init_diag(par_mean_t_down,                         &
+                                     'convection__par_mean_t_down')
+    if (par_mean_t_down_flag) call invoke( setval_c(par_mean_t_down,          &
+                                                    0.0_r_def) )
+
     if ( LPROF ) call stop_timing( id, 'diags.comorph' )
 
   end subroutine initialise_diags_for_comorph
@@ -176,7 +406,37 @@ contains
                                     par_radius_up,          &
                                     par_radius_down,        &
                                     freq_up,                &
-                                    freq_down)
+                                    freq_down,              &
+                                    par_mean_dtv_up,        &
+                                    par_mean_dtv_down,      &
+                                    par_mean_rhl_up,        &
+                                    par_mean_rhl_down,      &
+                                    par_mean_q_up,          &
+                                    par_mean_q_down,        &
+                                    par_mean_qcl_up,        &
+                                    par_mean_qcl_down,      &
+                                    par_mean_qcf_up,        &
+                                    par_mean_qcf_down,      &
+                                    par_mean_qrain_up,      &
+                                    par_mean_qrain_down,    &
+                                    par_mean_qgraup_up,     &
+                                    par_mean_qgraup_down,   &
+                                    par_mean_qsnow_up,      &
+                                    par_mean_qsnow_down,    &
+                                    par_mean_cfl_up,        &
+                                    par_mean_cfl_down,      &
+                                    par_mean_cff_up,        &
+                                    par_mean_cff_down,      &
+                                    par_mean_cfb_up,        &
+                                    par_mean_cfb_down,      &
+                                    par_mean_u_up,          &
+                                    par_mean_u_down,        &
+                                    par_mean_v_up,          &
+                                    par_mean_v_down,        &
+                                    par_mean_w_up,          &
+                                    par_mean_w_down,        &
+                                    par_mean_t_up,          &
+                                    par_mean_t_down)
 
     implicit none
 
@@ -220,7 +480,37 @@ contains
                                        par_radius_up,          &
                                        par_radius_down,        &
                                        freq_up,                &
-                                       freq_down
+                                       freq_down,              &
+                                       par_mean_dtv_up,        &
+                                       par_mean_dtv_down,      &
+                                       par_mean_rhl_up,        &
+                                       par_mean_rhl_down,      &
+                                       par_mean_q_up,          &
+                                       par_mean_q_down,        &
+                                       par_mean_qcl_up,        &
+                                       par_mean_qcl_down,      &
+                                       par_mean_qcf_up,        &
+                                       par_mean_qcf_down,      &
+                                       par_mean_qrain_up,      &
+                                       par_mean_qrain_down,    &
+                                       par_mean_qgraup_up,     &
+                                       par_mean_qgraup_down,   &
+                                       par_mean_qsnow_up,      &
+                                       par_mean_qsnow_down,    &
+                                       par_mean_cfl_up,        &
+                                       par_mean_cfl_down,      &
+                                       par_mean_cff_up,        &
+                                       par_mean_cff_down,      &
+                                       par_mean_cfb_up,        &
+                                       par_mean_cfb_down,      &
+                                       par_mean_u_up,          &
+                                       par_mean_u_down,        &
+                                       par_mean_v_up,          &
+                                       par_mean_v_down,        &
+                                       par_mean_w_up,          &
+                                       par_mean_w_down,        &
+                                       par_mean_t_up,          &
+                                       par_mean_t_down
     integer(tik)  :: id
 
     if ( LPROF ) call start_timing( id, 'diags.comorph' )
@@ -272,6 +562,36 @@ contains
     if (par_radius_down_flag) call par_radius_down%write_field()
     if (freq_up_flag) call freq_up%write_field()
     if (freq_down_flag) call freq_down%write_field()
+    if (par_mean_dtv_up_flag) call par_mean_dtv_up%write_field()
+    if (par_mean_dtv_down_flag) call par_mean_dtv_down%write_field()
+    if (par_mean_rhl_up_flag) call par_mean_rhl_up%write_field()
+    if (par_mean_rhl_down_flag) call par_mean_rhl_down%write_field()
+    if (par_mean_q_up_flag) call par_mean_q_up%write_field()
+    if (par_mean_q_down_flag) call par_mean_q_down%write_field()
+    if (par_mean_qcl_up_flag) call par_mean_qcl_up%write_field()
+    if (par_mean_qcl_down_flag) call par_mean_qcl_down%write_field()
+    if (par_mean_qcf_up_flag) call par_mean_qcf_up%write_field()
+    if (par_mean_qcf_down_flag) call par_mean_qcf_down%write_field()
+    if (par_mean_qrain_up_flag) call par_mean_qrain_up%write_field()
+    if (par_mean_qrain_down_flag) call par_mean_qrain_down%write_field()
+    if (par_mean_qgraup_up_flag) call par_mean_qgraup_up%write_field()
+    if (par_mean_qgraup_down_flag) call par_mean_qgraup_down%write_field()
+    if (par_mean_qsnow_up_flag) call par_mean_qsnow_up%write_field()
+    if (par_mean_qsnow_down_flag) call par_mean_qsnow_down%write_field()
+    if (par_mean_cfl_up_flag) call par_mean_cfl_up%write_field()
+    if (par_mean_cfl_down_flag) call par_mean_cfl_down%write_field()
+    if (par_mean_cff_up_flag) call par_mean_cff_up%write_field()
+    if (par_mean_cff_down_flag) call par_mean_cff_down%write_field()
+    if (par_mean_cfb_up_flag) call par_mean_cfb_up%write_field()
+    if (par_mean_cfb_down_flag) call par_mean_cfb_down%write_field()
+    if (par_mean_u_up_flag) call par_mean_u_up%write_field()
+    if (par_mean_u_down_flag) call par_mean_u_down%write_field()
+    if (par_mean_v_up_flag) call par_mean_v_up%write_field()
+    if (par_mean_v_down_flag) call par_mean_v_down%write_field()
+    if (par_mean_w_up_flag) call par_mean_w_up%write_field()
+    if (par_mean_w_down_flag) call par_mean_w_down%write_field()
+    if (par_mean_t_up_flag) call par_mean_t_up%write_field()
+    if (par_mean_t_down_flag) call par_mean_t_down%write_field()
 
     if ( LPROF ) call stop_timing( id, 'diags.comorph' )
 

--- a/interfaces/physics_schemes_interface/source/diagnostics/comorph_diags_mod.x90
+++ b/interfaces/physics_schemes_interface/source/diagnostics/comorph_diags_mod.x90
@@ -70,7 +70,13 @@ module comorph_diags_mod
                       par_core_dtv_up_flag,        &
                       par_core_dtv_down_flag,      &
                       par_core_rhl_up_flag,        &
-                      par_core_rhl_down_flag
+                      par_core_rhl_down_flag,      &
+                      turb_pert_u_flag,            &
+                      turb_pert_v_flag,            &
+                      turb_pert_w_flag,            &
+                      turb_pert_t_flag,            &
+                      turb_pert_q_flag,            &
+                      turb_radius_flag
 
   public :: initialise_diags_for_comorph
   public :: output_diags_for_comorph
@@ -129,7 +135,13 @@ contains
                                           par_core_dtv_up,        &
                                           par_core_dtv_down,      &
                                           par_core_rhl_up,        &
-                                          par_core_rhl_down)
+                                          par_core_rhl_down,      &
+                                          turb_pert_u,            &
+                                          turb_pert_v,            &
+                                          turb_pert_w,            &
+                                          turb_pert_t,            &
+                                          turb_pert_q,            &
+                                          turb_radius)
 
     implicit none
 
@@ -185,7 +197,13 @@ contains
                                          par_core_dtv_up,         &
                                          par_core_dtv_down,       &
                                          par_core_rhl_up,         &
-                                         par_core_rhl_down
+                                         par_core_rhl_down,       &
+                                         turb_pert_u,             &
+                                         turb_pert_v,             &
+                                         turb_pert_w,             &
+                                         turb_pert_t,             &
+                                         turb_pert_q,             &
+                                         turb_radius
     integer(tik)  :: id
 
     if ( LPROF ) call start_timing( id, 'diags.comorph' )
@@ -397,6 +415,24 @@ contains
     if (par_core_rhl_down_flag) call invoke( setval_c(par_core_rhl_down,      &
                                                       0.0_r_def) )
 
+    turb_pert_u_flag = init_diag(turb_pert_u, 'convection__turb_pert_u')
+    if (turb_pert_u_flag) call invoke( setval_c(turb_pert_u, 0.0_r_def) )
+
+    turb_pert_v_flag = init_diag(turb_pert_v, 'convection__turb_pert_v')
+    if (turb_pert_v_flag) call invoke( setval_c(turb_pert_v, 0.0_r_def) )
+
+    turb_pert_w_flag = init_diag(turb_pert_w, 'convection__turb_pert_w')
+    if (turb_pert_w_flag) call invoke( setval_c(turb_pert_w, 0.0_r_def) )
+
+    turb_pert_t_flag = init_diag(turb_pert_t, 'convection__turb_pert_t')
+    if (turb_pert_t_flag) call invoke( setval_c(turb_pert_t, 0.0_r_def) )
+
+    turb_pert_q_flag = init_diag(turb_pert_q, 'convection__turb_pert_q')
+    if (turb_pert_q_flag) call invoke( setval_c(turb_pert_q, 0.0_r_def) )
+
+    turb_radius_flag = init_diag(turb_radius, 'convection__turb_radius')
+    if (turb_radius_flag) call invoke( setval_c(turb_radius, 0.0_r_def) )
+
     if ( LPROF ) call stop_timing( id, 'diags.comorph' )
 
   end subroutine initialise_diags_for_comorph
@@ -472,7 +508,13 @@ contains
                                     par_core_dtv_up,        &
                                     par_core_dtv_down,      &
                                     par_core_rhl_up,        &
-                                    par_core_rhl_down)
+                                    par_core_rhl_down,      &
+                                    turb_pert_u,            &
+                                    turb_pert_v,            &
+                                    turb_pert_w,            &
+                                    turb_pert_t,            &
+                                    turb_pert_q,            &
+                                    turb_radius)
 
     implicit none
 
@@ -550,7 +592,13 @@ contains
                                        par_core_dtv_up,        &
                                        par_core_dtv_down,      &
                                        par_core_rhl_up,        &
-                                       par_core_rhl_down
+                                       par_core_rhl_down,      &
+                                       turb_pert_u,            &
+                                       turb_pert_v,            &
+                                       turb_pert_w,            &
+                                       turb_pert_t,            &
+                                       turb_pert_q,            &
+                                       turb_radius
     integer(tik)  :: id
 
     if ( LPROF ) call start_timing( id, 'diags.comorph' )
@@ -636,6 +684,12 @@ contains
     if (par_core_dtv_down_flag) call par_core_dtv_down%write_field()
     if (par_core_rhl_up_flag) call par_core_rhl_up%write_field()
     if (par_core_rhl_down_flag) call par_core_rhl_down%write_field()
+    if (turb_pert_u_flag) call turb_pert_u%write_field()
+    if (turb_pert_v_flag) call turb_pert_v%write_field()
+    if (turb_pert_w_flag) call turb_pert_w%write_field()
+    if (turb_pert_t_flag) call turb_pert_t%write_field()
+    if (turb_pert_q_flag) call turb_pert_q%write_field()
+    if (turb_radius_flag) call turb_radius%write_field()
 
     if ( LPROF ) call stop_timing( id, 'diags.comorph' )
 

--- a/interfaces/physics_schemes_interface/source/diagnostics/comorph_diags_mod.x90
+++ b/interfaces/physics_schemes_interface/source/diagnostics/comorph_diags_mod.x90
@@ -76,7 +76,24 @@ module comorph_diags_mod
                       turb_pert_w_flag,            &
                       turb_pert_t_flag,            &
                       turb_pert_q_flag,            &
-                      turb_radius_flag
+                      turb_radius_flag,            &
+                      subreg_dry_frac_flag,        &
+                      subreg_liq_frac_flag,        &
+                      subreg_mph_frac_flag,        &
+                      subreg_icr_frac_flag,        &
+                      subreg_dry_t_flag,           &
+                      subreg_liq_t_flag,           &
+                      subreg_mph_t_flag,           &
+                      subreg_icr_t_flag,           &
+                      subreg_dry_q_flag,           &
+                      subreg_liq_q_flag,           &
+                      subreg_mph_q_flag,           &
+                      subreg_icr_q_flag,           &
+                      subreg_dry_rhl_flag,         &
+                      subreg_liq_rhl_flag,         &
+                      subreg_mph_rhl_flag,         &
+                      subreg_icr_rhl_flag,         &
+                      massflux_down_half_flag
 
   public :: initialise_diags_for_comorph
   public :: output_diags_for_comorph
@@ -141,7 +158,24 @@ contains
                                           turb_pert_w,            &
                                           turb_pert_t,            &
                                           turb_pert_q,            &
-                                          turb_radius)
+                                          turb_radius,            &
+                                          subreg_dry_frac,        &
+                                          subreg_liq_frac,        &
+                                          subreg_mph_frac,        &
+                                          subreg_icr_frac,        &
+                                          subreg_dry_t,           &
+                                          subreg_liq_t,           &
+                                          subreg_mph_t,           &
+                                          subreg_icr_t,           &
+                                          subreg_dry_q,           &
+                                          subreg_liq_q,           &
+                                          subreg_mph_q,           &
+                                          subreg_icr_q,           &
+                                          subreg_dry_rhl,         &
+                                          subreg_liq_rhl,         &
+                                          subreg_mph_rhl,         &
+                                          subreg_icr_rhl,         &
+                                          massflux_down_half)
 
     implicit none
 
@@ -203,7 +237,24 @@ contains
                                          turb_pert_w,             &
                                          turb_pert_t,             &
                                          turb_pert_q,             &
-                                         turb_radius
+                                         turb_radius,             &
+                                         subreg_dry_frac,         &
+                                         subreg_liq_frac,         &
+                                         subreg_mph_frac,         &
+                                         subreg_icr_frac,         &
+                                         subreg_dry_t,            &
+                                         subreg_liq_t,            &
+                                         subreg_mph_t,            &
+                                         subreg_icr_t,            &
+                                         subreg_dry_q,            &
+                                         subreg_liq_q,            &
+                                         subreg_mph_q,            &
+                                         subreg_icr_q,            &
+                                         subreg_dry_rhl,          &
+                                         subreg_liq_rhl,          &
+                                         subreg_mph_rhl,          &
+                                         subreg_icr_rhl,          &
+                                         massflux_down_half
     integer(tik)  :: id
 
     if ( LPROF ) call start_timing( id, 'diags.comorph' )
@@ -433,6 +484,71 @@ contains
     turb_radius_flag = init_diag(turb_radius, 'convection__turb_radius')
     if (turb_radius_flag) call invoke( setval_c(turb_radius, 0.0_r_def) )
 
+    subreg_dry_frac_flag = init_diag(subreg_dry_frac,                          &
+                                     'convection__subreg_dry_frac')
+    if (subreg_dry_frac_flag) call invoke( setval_c(subreg_dry_frac,           &
+                                                    0.0_r_def) )
+
+    subreg_liq_frac_flag = init_diag(subreg_liq_frac,                          &
+                                     'convection__subreg_liq_frac')
+    if (subreg_liq_frac_flag) call invoke( setval_c(subreg_liq_frac,           &
+                                                    0.0_r_def) )
+
+    subreg_mph_frac_flag = init_diag(subreg_mph_frac,                          &
+                                     'convection__subreg_mph_frac')
+    if (subreg_mph_frac_flag) call invoke( setval_c(subreg_mph_frac,           &
+                                                    0.0_r_def) )
+
+    subreg_icr_frac_flag = init_diag(subreg_icr_frac,                          &
+                                     'convection__subreg_icr_frac')
+    if (subreg_icr_frac_flag) call invoke( setval_c(subreg_icr_frac,           &
+                                                    0.0_r_def) )
+
+    subreg_dry_t_flag = init_diag(subreg_dry_t, 'convection__subreg_dry_t')
+    if (subreg_dry_t_flag) call invoke( setval_c(subreg_dry_t, 0.0_r_def) )
+
+    subreg_liq_t_flag = init_diag(subreg_liq_t, 'convection__subreg_liq_t')
+    if (subreg_liq_t_flag) call invoke( setval_c(subreg_liq_t, 0.0_r_def) )
+
+    subreg_mph_t_flag = init_diag(subreg_mph_t, 'convection__subreg_mph_t')
+    if (subreg_mph_t_flag) call invoke( setval_c(subreg_mph_t, 0.0_r_def) )
+
+    subreg_icr_t_flag = init_diag(subreg_icr_t, 'convection__subreg_icr_t')
+    if (subreg_icr_t_flag) call invoke( setval_c(subreg_icr_t, 0.0_r_def) )
+
+    subreg_dry_q_flag = init_diag(subreg_dry_q, 'convection__subreg_dry_q')
+    if (subreg_dry_q_flag) call invoke( setval_c(subreg_dry_q, 0.0_r_def) )
+
+    subreg_liq_q_flag = init_diag(subreg_liq_q, 'convection__subreg_liq_q')
+    if (subreg_liq_q_flag) call invoke( setval_c(subreg_liq_q, 0.0_r_def) )
+
+    subreg_mph_q_flag = init_diag(subreg_mph_q, 'convection__subreg_mph_q')
+    if (subreg_mph_q_flag) call invoke( setval_c(subreg_mph_q, 0.0_r_def) )
+
+    subreg_icr_q_flag = init_diag(subreg_icr_q, 'convection__subreg_icr_q')
+    if (subreg_icr_q_flag) call invoke( setval_c(subreg_icr_q, 0.0_r_def) )
+
+    subreg_dry_rhl_flag = init_diag(subreg_dry_rhl,                            &
+                                    'convection__subreg_dry_rhl')
+    if (subreg_dry_rhl_flag) call invoke( setval_c(subreg_dry_rhl, 0.0_r_def) )
+
+    subreg_liq_rhl_flag = init_diag(subreg_liq_rhl,                            &
+                                    'convection__subreg_liq_rhl')
+    if (subreg_liq_rhl_flag) call invoke( setval_c(subreg_liq_rhl, 0.0_r_def) )
+
+    subreg_mph_rhl_flag = init_diag(subreg_mph_rhl,                            &
+                                    'convection__subreg_mph_rhl')
+    if (subreg_mph_rhl_flag) call invoke( setval_c(subreg_mph_rhl, 0.0_r_def) )
+
+    subreg_icr_rhl_flag = init_diag(subreg_icr_rhl,                            &
+                                    'convection__subreg_icr_rhl')
+    if (subreg_icr_rhl_flag) call invoke( setval_c(subreg_icr_rhl, 0.0_r_def) )
+
+    massflux_down_half_flag = init_diag(massflux_down_half,                    &
+                                        'convection__massflux_down_half')
+    if (massflux_down_half_flag) call invoke( setval_c(massflux_down_half,     &
+                                                       0.0_r_def) )
+
     if ( LPROF ) call stop_timing( id, 'diags.comorph' )
 
   end subroutine initialise_diags_for_comorph
@@ -514,7 +630,24 @@ contains
                                     turb_pert_w,            &
                                     turb_pert_t,            &
                                     turb_pert_q,            &
-                                    turb_radius)
+                                    turb_radius,            &
+                                    subreg_dry_frac,        &
+                                    subreg_liq_frac,        &
+                                    subreg_mph_frac,        &
+                                    subreg_icr_frac,        &
+                                    subreg_dry_t,           &
+                                    subreg_liq_t,           &
+                                    subreg_mph_t,           &
+                                    subreg_icr_t,           &
+                                    subreg_dry_q,           &
+                                    subreg_liq_q,           &
+                                    subreg_mph_q,           &
+                                    subreg_icr_q,           &
+                                    subreg_dry_rhl,         &
+                                    subreg_liq_rhl,         &
+                                    subreg_mph_rhl,         &
+                                    subreg_icr_rhl,         &
+                                    massflux_down_half)
 
     implicit none
 
@@ -598,7 +731,24 @@ contains
                                        turb_pert_w,            &
                                        turb_pert_t,            &
                                        turb_pert_q,            &
-                                       turb_radius
+                                       turb_radius,            &
+                                       subreg_dry_frac,        &
+                                       subreg_liq_frac,        &
+                                       subreg_mph_frac,        &
+                                       subreg_icr_frac,        &
+                                       subreg_dry_t,           &
+                                       subreg_liq_t,           &
+                                       subreg_mph_t,           &
+                                       subreg_icr_t,           &
+                                       subreg_dry_q,           &
+                                       subreg_liq_q,           &
+                                       subreg_mph_q,           &
+                                       subreg_icr_q,           &
+                                       subreg_dry_rhl,         &
+                                       subreg_liq_rhl,         &
+                                       subreg_mph_rhl,         &
+                                       subreg_icr_rhl,         &
+                                       massflux_down_half
     integer(tik)  :: id
 
     if ( LPROF ) call start_timing( id, 'diags.comorph' )
@@ -690,6 +840,23 @@ contains
     if (turb_pert_t_flag) call turb_pert_t%write_field()
     if (turb_pert_q_flag) call turb_pert_q%write_field()
     if (turb_radius_flag) call turb_radius%write_field()
+    if (subreg_dry_frac_flag) call subreg_dry_frac%write_field()
+    if (subreg_liq_frac_flag) call subreg_liq_frac%write_field()
+    if (subreg_mph_frac_flag) call subreg_mph_frac%write_field()
+    if (subreg_icr_frac_flag) call subreg_icr_frac%write_field()
+    if (subreg_dry_t_flag) call subreg_dry_t%write_field()
+    if (subreg_liq_t_flag) call subreg_liq_t%write_field()
+    if (subreg_mph_t_flag) call subreg_mph_t%write_field()
+    if (subreg_icr_t_flag) call subreg_icr_t%write_field()
+    if (subreg_dry_q_flag) call subreg_dry_q%write_field()
+    if (subreg_liq_q_flag) call subreg_liq_q%write_field()
+    if (subreg_mph_q_flag) call subreg_mph_q%write_field()
+    if (subreg_icr_q_flag) call subreg_icr_q%write_field()
+    if (subreg_dry_rhl_flag) call subreg_dry_rhl%write_field()
+    if (subreg_liq_rhl_flag) call subreg_liq_rhl%write_field()
+    if (subreg_mph_rhl_flag) call subreg_mph_rhl%write_field()
+    if (subreg_icr_rhl_flag) call subreg_icr_rhl%write_field()
+    if (massflux_down_half_flag) call massflux_down_half%write_field()
 
     if ( LPROF ) call stop_timing( id, 'diags.comorph' )
 

--- a/interfaces/physics_schemes_interface/source/diagnostics/comorph_diags_mod.x90
+++ b/interfaces/physics_schemes_interface/source/diagnostics/comorph_diags_mod.x90
@@ -34,7 +34,9 @@ module comorph_diags_mod
                       detrain_down_flag,           &
                       massflux_up_half_flag,       &
                       par_radius_up_flag,          &
-                      par_radius_down_flag
+                      par_radius_down_flag,        &
+                      freq_up_flag,                &
+                      freq_down_flag
 
   public :: initialise_diags_for_comorph
   public :: output_diags_for_comorph
@@ -57,7 +59,9 @@ contains
                                           detrain_down,           &
                                           massflux_up_half,       &
                                           par_radius_up,          &
-                                          par_radius_down)
+                                          par_radius_down,        &
+                                          freq_up,                &
+                                          freq_down)
 
     implicit none
 
@@ -77,7 +81,9 @@ contains
                                          detrain_down,            &
                                          massflux_up_half,        &
                                          par_radius_up,           &
-                                         par_radius_down
+                                         par_radius_down,         &
+                                         freq_up,                 &
+                                         freq_down
     integer(tik)  :: id
 
     if ( LPROF ) call start_timing( id, 'diags.comorph' )
@@ -123,6 +129,12 @@ contains
     if (par_radius_down_flag) call invoke( setval_c(par_radius_down,           &
                                                     0.0_r_def) )
 
+    freq_up_flag = init_diag(freq_up, 'convection__freq_up')
+    if (freq_up_flag) call invoke( setval_c(freq_up, 0.0_r_def) )
+
+    freq_down_flag = init_diag(freq_down, 'convection__freq_down')
+    if (freq_down_flag) call invoke( setval_c(freq_down, 0.0_r_def) )
+
     if ( LPROF ) call stop_timing( id, 'diags.comorph' )
 
   end subroutine initialise_diags_for_comorph
@@ -162,7 +174,9 @@ contains
                                     detrain_down,           &
                                     massflux_up_half,       &
                                     par_radius_up,          &
-                                    par_radius_down)
+                                    par_radius_down,        &
+                                    freq_up,                &
+                                    freq_down)
 
     implicit none
 
@@ -204,7 +218,9 @@ contains
                                        detrain_down,           &
                                        massflux_up_half,       &
                                        par_radius_up,          &
-                                       par_radius_down
+                                       par_radius_down,        &
+                                       freq_up,                &
+                                       freq_down
     integer(tik)  :: id
 
     if ( LPROF ) call start_timing( id, 'diags.comorph' )
@@ -254,6 +270,8 @@ contains
     if (massflux_up_half_flag) call massflux_up_half%write_field()
     if (par_radius_up_flag) call par_radius_up%write_field()
     if (par_radius_down_flag) call par_radius_down%write_field()
+    if (freq_up_flag) call freq_up%write_field()
+    if (freq_down_flag) call freq_down%write_field()
 
     if ( LPROF ) call stop_timing( id, 'diags.comorph' )
 

--- a/interfaces/physics_schemes_interface/source/diagnostics/comorph_diags_mod.x90
+++ b/interfaces/physics_schemes_interface/source/diagnostics/comorph_diags_mod.x90
@@ -66,7 +66,11 @@ module comorph_diags_mod
                       par_mean_w_up_flag,          &
                       par_mean_w_down_flag,        &
                       par_mean_t_up_flag,          &
-                      par_mean_t_down_flag
+                      par_mean_t_down_flag,        &
+                      par_core_dtv_up_flag,        &
+                      par_core_dtv_down_flag,      &
+                      par_core_rhl_up_flag,        &
+                      par_core_rhl_down_flag
 
   public :: initialise_diags_for_comorph
   public :: output_diags_for_comorph
@@ -121,7 +125,11 @@ contains
                                           par_mean_w_up,          &
                                           par_mean_w_down,        &
                                           par_mean_t_up,          &
-                                          par_mean_t_down)
+                                          par_mean_t_down,        &
+                                          par_core_dtv_up,        &
+                                          par_core_dtv_down,      &
+                                          par_core_rhl_up,        &
+                                          par_core_rhl_down)
 
     implicit none
 
@@ -173,7 +181,11 @@ contains
                                          par_mean_w_up,           &
                                          par_mean_w_down,         &
                                          par_mean_t_up,           &
-                                         par_mean_t_down
+                                         par_mean_t_down,         &
+                                         par_core_dtv_up,         &
+                                         par_core_dtv_down,       &
+                                         par_core_rhl_up,         &
+                                         par_core_rhl_down
     integer(tik)  :: id
 
     if ( LPROF ) call start_timing( id, 'diags.comorph' )
@@ -365,6 +377,26 @@ contains
     if (par_mean_t_down_flag) call invoke( setval_c(par_mean_t_down,          &
                                                     0.0_r_def) )
 
+    par_core_dtv_up_flag = init_diag(par_core_dtv_up,                         &
+                                     'convection__par_core_dtv_up')
+    if (par_core_dtv_up_flag) call invoke( setval_c(par_core_dtv_up,          &
+                                                    0.0_r_def) )
+
+    par_core_dtv_down_flag = init_diag(par_core_dtv_down,                     &
+                                       'convection__par_core_dtv_down')
+    if (par_core_dtv_down_flag) call invoke( setval_c(par_core_dtv_down,      &
+                                                      0.0_r_def) )
+
+    par_core_rhl_up_flag = init_diag(par_core_rhl_up,                         &
+                                     'convection__par_core_rhl_up')
+    if (par_core_rhl_up_flag) call invoke( setval_c(par_core_rhl_up,          &
+                                                    0.0_r_def) )
+
+    par_core_rhl_down_flag = init_diag(par_core_rhl_down,                     &
+                                       'convection__par_core_rhl_down')
+    if (par_core_rhl_down_flag) call invoke( setval_c(par_core_rhl_down,      &
+                                                      0.0_r_def) )
+
     if ( LPROF ) call stop_timing( id, 'diags.comorph' )
 
   end subroutine initialise_diags_for_comorph
@@ -436,7 +468,11 @@ contains
                                     par_mean_w_up,          &
                                     par_mean_w_down,        &
                                     par_mean_t_up,          &
-                                    par_mean_t_down)
+                                    par_mean_t_down,        &
+                                    par_core_dtv_up,        &
+                                    par_core_dtv_down,      &
+                                    par_core_rhl_up,        &
+                                    par_core_rhl_down)
 
     implicit none
 
@@ -510,7 +546,11 @@ contains
                                        par_mean_w_up,          &
                                        par_mean_w_down,        &
                                        par_mean_t_up,          &
-                                       par_mean_t_down
+                                       par_mean_t_down,        &
+                                       par_core_dtv_up,        &
+                                       par_core_dtv_down,      &
+                                       par_core_rhl_up,        &
+                                       par_core_rhl_down
     integer(tik)  :: id
 
     if ( LPROF ) call start_timing( id, 'diags.comorph' )
@@ -592,6 +632,10 @@ contains
     if (par_mean_w_down_flag) call par_mean_w_down%write_field()
     if (par_mean_t_up_flag) call par_mean_t_up%write_field()
     if (par_mean_t_down_flag) call par_mean_t_down%write_field()
+    if (par_core_dtv_up_flag) call par_core_dtv_up%write_field()
+    if (par_core_dtv_down_flag) call par_core_dtv_down%write_field()
+    if (par_core_rhl_up_flag) call par_core_rhl_up%write_field()
+    if (par_core_rhl_down_flag) call par_core_rhl_down%write_field()
 
     if ( LPROF ) call stop_timing( id, 'diags.comorph' )
 

--- a/interfaces/physics_schemes_interface/source/diagnostics/comorph_diags_mod.x90
+++ b/interfaces/physics_schemes_interface/source/diagnostics/comorph_diags_mod.x90
@@ -3,6 +3,9 @@
 ! The file LICENCE, distributed with this code, contains details of the terms
 ! under which the code may be used.
 !-------------------------------------------------------------------------------
+! Some of the content of this file has been produced with the assistance of
+! Anthropic Claude Opus 5 (Claude Code).
+!-------------------------------------------------------------------------------
 !> @brief Processes diagnostics for comorph_alg
 
 module comorph_diags_mod
@@ -29,7 +32,9 @@ module comorph_diags_mod
                       entrain_down_flag,           &
                       detrain_up_flag,             &
                       detrain_down_flag,           &
-                      massflux_up_half_flag
+                      massflux_up_half_flag,       &
+                      par_radius_up_flag,          &
+                      par_radius_down_flag
 
   public :: initialise_diags_for_comorph
   public :: output_diags_for_comorph
@@ -50,7 +55,9 @@ contains
                                           entrain_down,           &
                                           detrain_up,             &
                                           detrain_down,           &
-                                          massflux_up_half)
+                                          massflux_up_half,       &
+                                          par_radius_up,          &
+                                          par_radius_down)
 
     implicit none
 
@@ -68,7 +75,9 @@ contains
                                          entrain_down,            &
                                          detrain_up,              &
                                          detrain_down,            &
-                                         massflux_up_half
+                                         massflux_up_half,        &
+                                         par_radius_up,           &
+                                         par_radius_down
     integer(tik)  :: id
 
     if ( LPROF ) call start_timing( id, 'diags.comorph' )
@@ -104,6 +113,15 @@ contains
     if (detrain_down_flag) call invoke( setval_c(detrain_down, 0.0_r_def) )
 
     massflux_up_half_flag = init_diag(massflux_up_half, 'convection__massflux_up_half')
+
+    ! Convective diagnostics - 3d  - rho levels
+    par_radius_up_flag = init_diag(par_radius_up, 'convection__par_radius_up')
+    if (par_radius_up_flag) call invoke( setval_c(par_radius_up, 0.0_r_def) )
+
+    par_radius_down_flag = init_diag(par_radius_down, &
+                                     'convection__par_radius_down')
+    if (par_radius_down_flag) call invoke( setval_c(par_radius_down,           &
+                                                    0.0_r_def) )
 
     if ( LPROF ) call stop_timing( id, 'diags.comorph' )
 
@@ -142,7 +160,9 @@ contains
                                     entrain_down,           &
                                     detrain_up,             &
                                     detrain_down,           &
-                                    massflux_up_half)
+                                    massflux_up_half,       &
+                                    par_radius_up,          &
+                                    par_radius_down)
 
     implicit none
 
@@ -182,7 +202,9 @@ contains
                                        entrain_down,           &
                                        detrain_up,             &
                                        detrain_down,           &
-                                       massflux_up_half
+                                       massflux_up_half,       &
+                                       par_radius_up,          &
+                                       par_radius_down
     integer(tik)  :: id
 
     if ( LPROF ) call start_timing( id, 'diags.comorph' )
@@ -230,6 +252,8 @@ contains
     if (detrain_up_flag) call detrain_up%write_field()
     if (detrain_down_flag) call detrain_down%write_field()
     if (massflux_up_half_flag) call massflux_up_half%write_field()
+    if (par_radius_up_flag) call par_radius_up%write_field()
+    if (par_radius_down_flag) call par_radius_down%write_field()
 
     if ( LPROF ) call stop_timing( id, 'diags.comorph' )
 

--- a/interfaces/physics_schemes_interface/source/kernel/conv_comorph_kernel_mod.F90
+++ b/interfaces/physics_schemes_interface/source/kernel/conv_comorph_kernel_mod.F90
@@ -36,7 +36,7 @@ module conv_comorph_kernel_mod
   !>
   type, public, extends(kernel_type) :: conv_comorph_kernel_type
     private
-    type(arg_type) :: meta_args(199) = (/                                         &
+    type(arg_type) :: meta_args(229) = (/                                         &
          arg_type(GH_SCALAR, GH_INTEGER, GH_READ),                                &! outer
          arg_type(GH_FIELD,  GH_REAL,    GH_READ,      W3),                       &! rho_in_w3
          arg_type(GH_FIELD,  GH_REAL,    GH_READ,      WTHETA),                   &! rho_in_wth
@@ -235,7 +235,37 @@ module conv_comorph_kernel_mod
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_radius_up
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_radius_down
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! freq_up
-         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3)                        &! freq_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! freq_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_dtv_up
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_dtv_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_rhl_up
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_rhl_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_q_up
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_q_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_qcl_up
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_qcl_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_qcf_up
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_qcf_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_qrain_up
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_qrain_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_qgraup_up
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_qgraup_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_qsnow_up
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_qsnow_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_cfl_up
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_cfl_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_cff_up
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_cff_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_cfb_up
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_cfb_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_u_up
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_u_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_v_up
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_v_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_w_up
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_w_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_t_up
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3)                        &! par_mean_t_down
         /)
     integer :: operates_on = DOMAIN
   contains
@@ -446,6 +476,36 @@ contains
   !> @param[in,out] par_radius_down      Mean downdraught parcel radius on half-levels (m)
   !> @param[in,out] freq_up              Frequency of updraught on half-levels
   !> @param[in,out] freq_down            Frequency of downdraught on half-levels
+  !> @param[in,out] par_mean_dtv_up      Mean updraught parcel excess virtual temperature (K)
+  !> @param[in,out] par_mean_dtv_down    Mean downdraught parcel excess virtual temperature (K)
+  !> @param[in,out] par_mean_rhl_up      Mean updraught parcel relative humidity wrt liquid
+  !> @param[in,out] par_mean_rhl_down    Mean downdraught parcel relative humidity wrt liquid
+  !> @param[in,out] par_mean_q_up        Mean updraught parcel water vapour (kg/kg)
+  !> @param[in,out] par_mean_q_down      Mean downdraught parcel water vapour (kg/kg)
+  !> @param[in,out] par_mean_qcl_up      Mean updraught parcel liquid water (kg/kg)
+  !> @param[in,out] par_mean_qcl_down    Mean downdraught parcel liquid water (kg/kg)
+  !> @param[in,out] par_mean_qcf_up      Mean updraught parcel ice water (kg/kg)
+  !> @param[in,out] par_mean_qcf_down    Mean downdraught parcel ice water (kg/kg)
+  !> @param[in,out] par_mean_qrain_up    Mean updraught parcel rain (kg/kg)
+  !> @param[in,out] par_mean_qrain_down  Mean downdraught parcel rain (kg/kg)
+  !> @param[in,out] par_mean_qgraup_up   Mean updraught parcel graupel (kg/kg)
+  !> @param[in,out] par_mean_qgraup_down Mean downdraught parcel graupel (kg/kg)
+  !> @param[in,out] par_mean_qsnow_up    Mean updraught parcel snow (kg/kg)
+  !> @param[in,out] par_mean_qsnow_down  Mean downdraught parcel snow (kg/kg)
+  !> @param[in,out] par_mean_cfl_up      Mean updraught parcel liquid cloud fraction
+  !> @param[in,out] par_mean_cfl_down    Mean downdraught parcel liquid cloud fraction
+  !> @param[in,out] par_mean_cff_up      Mean updraught parcel ice cloud fraction
+  !> @param[in,out] par_mean_cff_down    Mean downdraught parcel ice cloud fraction
+  !> @param[in,out] par_mean_cfb_up      Mean updraught parcel bulk cloud fraction
+  !> @param[in,out] par_mean_cfb_down    Mean downdraught parcel bulk cloud fraction
+  !> @param[in,out] par_mean_u_up        Mean updraught parcel u wind (m/s)
+  !> @param[in,out] par_mean_u_down      Mean downdraught parcel u wind (m/s)
+  !> @param[in,out] par_mean_v_up        Mean updraught parcel v wind (m/s)
+  !> @param[in,out] par_mean_v_down      Mean downdraught parcel v wind (m/s)
+  !> @param[in,out] par_mean_w_up        Mean updraught parcel w wind (m/s)
+  !> @param[in,out] par_mean_w_down      Mean downdraught parcel w wind (m/s)
+  !> @param[in,out] par_mean_t_up        Mean updraught parcel temperature (K)
+  !> @param[in,out] par_mean_t_down      Mean downdraught parcel temperature (K)
   !> @param[in]     ndf_w3               Number of DOFs per cell for density space
   !> @param[in]     undf_w3              Number of unique DOFs  for density space
   !> @param[in]     map_w3               Dofmap for the cell at the base of the column for density space
@@ -661,6 +721,36 @@ contains
                           par_radius_down,                   &
                           freq_up,                           &
                           freq_down,                         &
+                          par_mean_dtv_up,                   &
+                          par_mean_dtv_down,                 &
+                          par_mean_rhl_up,                   &
+                          par_mean_rhl_down,                 &
+                          par_mean_q_up,                     &
+                          par_mean_q_down,                   &
+                          par_mean_qcl_up,                   &
+                          par_mean_qcl_down,                 &
+                          par_mean_qcf_up,                   &
+                          par_mean_qcf_down,                 &
+                          par_mean_qrain_up,                 &
+                          par_mean_qrain_down,               &
+                          par_mean_qgraup_up,                &
+                          par_mean_qgraup_down,              &
+                          par_mean_qsnow_up,                 &
+                          par_mean_qsnow_down,               &
+                          par_mean_cfl_up,                   &
+                          par_mean_cfl_down,                 &
+                          par_mean_cff_up,                   &
+                          par_mean_cff_down,                 &
+                          par_mean_cfb_up,                   &
+                          par_mean_cfb_down,                 &
+                          par_mean_u_up,                     &
+                          par_mean_u_down,                   &
+                          par_mean_v_up,                     &
+                          par_mean_v_down,                   &
+                          par_mean_w_up,                     &
+                          par_mean_w_down,                   &
+                          par_mean_t_up,                     &
+                          par_mean_t_down,                   &
                           ndf_w3,                            &
                           undf_w3,                           &
                           map_w3,                            &
@@ -824,7 +914,7 @@ contains
     use comorph_diags_type_mod, only: comorph_diags_type
     use set_constants_from_um_mod, only: set_constants_from_um
     use comorph_constants_mod, only: l_init_constants, l_turb_par_gen,         &
-         l_cv_rain, l_cv_cf, l_cv_snow, l_cv_graup,                            &
+         l_cv_rain, l_cv_cf, l_cv_snow, l_cv_graup, l_cv_cloudfrac,            &
          i_convcloud, i_convcloud_liqonly
     use calc_conv_incs_mod, only: calc_conv_incs, i_call_save_before_conv,     &
          i_call_diff_to_get_incs
@@ -1032,6 +1122,37 @@ contains
                                                 par_radius_down(:),  &
                                                 freq_up(:),          &
                                                 freq_down(:)
+
+    real(kind=r_def), pointer, intent(inout) :: par_mean_dtv_up(:),            &
+                                                par_mean_dtv_down(:),          &
+                                                par_mean_rhl_up(:),            &
+                                                par_mean_rhl_down(:),          &
+                                                par_mean_q_up(:),              &
+                                                par_mean_q_down(:),            &
+                                                par_mean_qcl_up(:),            &
+                                                par_mean_qcl_down(:),          &
+                                                par_mean_qcf_up(:),            &
+                                                par_mean_qcf_down(:),          &
+                                                par_mean_qrain_up(:),          &
+                                                par_mean_qrain_down(:),        &
+                                                par_mean_qgraup_up(:),         &
+                                                par_mean_qgraup_down(:),       &
+                                                par_mean_qsnow_up(:),          &
+                                                par_mean_qsnow_down(:),        &
+                                                par_mean_cfl_up(:),            &
+                                                par_mean_cfl_down(:),          &
+                                                par_mean_cff_up(:),            &
+                                                par_mean_cff_down(:),          &
+                                                par_mean_cfb_up(:),            &
+                                                par_mean_cfb_down(:),          &
+                                                par_mean_u_up(:),              &
+                                                par_mean_u_down(:),            &
+                                                par_mean_v_up(:),              &
+                                                par_mean_v_down(:),            &
+                                                par_mean_w_up(:),              &
+                                                par_mean_w_down(:),            &
+                                                par_mean_t_up(:),              &
+                                                par_mean_t_down(:)
 
     real(kind=r_def), dimension(undf_wth), intent(inout) :: dcfl_conv
     real(kind=r_def), dimension(undf_wth), intent(inout) :: dcff_conv
@@ -1246,6 +1367,14 @@ contains
     real(kind=r_um), target :: down_flux_half(row_length, rows, nlayers)
     real(kind=r_um), target, allocatable, dimension(:,:,:) :: ent_up, ent_down,&
          det_up, det_down, pres_inc_env, rad_up, rad_down
+    real(kind=r_um), target, allocatable, dimension(:,:,:) ::                  &
+         mean_dtv_up, mean_dtv_down, mean_rhl_up, mean_rhl_down, mean_q_up,    &
+         mean_q_down, mean_qcl_up, mean_qcl_down, mean_qcf_up, mean_qcf_down,  &
+         mean_qrain_up, mean_qrain_down, mean_qgraup_up, mean_qgraup_down,     &
+         mean_qsnow_up, mean_qsnow_down, mean_cfl_up, mean_cfl_down,           &
+         mean_cff_up, mean_cff_down, mean_cfb_up, mean_cfb_down, mean_u_up,    &
+         mean_u_down, mean_v_up, mean_v_down, mean_w_up, mean_w_down,          &
+         mean_t_up, mean_t_down
 
     !-----------------------------------------------------------------------
     ! Mapping of LFRic fields into CoMorph 3D arrays
@@ -2364,6 +2493,233 @@ contains
         comorph_diags % dndraft % par % radius                                 &
                                 % field_3d => rad_down
       end if
+
+      ! Set requests and assign pointers for the mean parcel property
+      ! diagnostics.  CoMorph calculates these on rho-levels.  Those for
+      ! the optional hydrometeors and the cloud fractions can only be
+      ! requested when convection is acting on them.
+      if (.not. associated(par_mean_dtv_up, empty_real_data) ) then
+        allocate(mean_dtv_up(row_length,rows,nlayers))
+        comorph_diags % updraft % par % mean % virt_temp_excess                &
+                                % request % x_y_z = .true.
+        comorph_diags % updraft % par % mean % virt_temp_excess                &
+                                % field_3d => mean_dtv_up
+      end if
+      if (.not. associated(par_mean_dtv_down, empty_real_data) ) then
+        allocate(mean_dtv_down(row_length,rows,nlayers))
+        comorph_diags % dndraft % par % mean % virt_temp_excess                &
+                                % request % x_y_z = .true.
+        comorph_diags % dndraft % par % mean % virt_temp_excess                &
+                                % field_3d => mean_dtv_down
+      end if
+      if (.not. associated(par_mean_rhl_up, empty_real_data) ) then
+        allocate(mean_rhl_up(row_length,rows,nlayers))
+        comorph_diags % updraft % par % mean % rel_hum_liq                     &
+                                % request % x_y_z = .true.
+        comorph_diags % updraft % par % mean % rel_hum_liq                     &
+                                % field_3d => mean_rhl_up
+      end if
+      if (.not. associated(par_mean_rhl_down, empty_real_data) ) then
+        allocate(mean_rhl_down(row_length,rows,nlayers))
+        comorph_diags % dndraft % par % mean % rel_hum_liq                     &
+                                % request % x_y_z = .true.
+        comorph_diags % dndraft % par % mean % rel_hum_liq                     &
+                                % field_3d => mean_rhl_down
+      end if
+      if (.not. associated(par_mean_q_up, empty_real_data) ) then
+        allocate(mean_q_up(row_length,rows,nlayers))
+        comorph_diags % updraft % par % mean % q_vap                           &
+                                % request % x_y_z = .true.
+        comorph_diags % updraft % par % mean % q_vap                           &
+                                % field_3d => mean_q_up
+      end if
+      if (.not. associated(par_mean_q_down, empty_real_data) ) then
+        allocate(mean_q_down(row_length,rows,nlayers))
+        comorph_diags % dndraft % par % mean % q_vap                           &
+                                % request % x_y_z = .true.
+        comorph_diags % dndraft % par % mean % q_vap                           &
+                                % field_3d => mean_q_down
+      end if
+      if (.not. associated(par_mean_qcl_up, empty_real_data) ) then
+        allocate(mean_qcl_up(row_length,rows,nlayers))
+        comorph_diags % updraft % par % mean % q_cl                            &
+                                % request % x_y_z = .true.
+        comorph_diags % updraft % par % mean % q_cl                            &
+                                % field_3d => mean_qcl_up
+      end if
+      if (.not. associated(par_mean_qcl_down, empty_real_data) ) then
+        allocate(mean_qcl_down(row_length,rows,nlayers))
+        comorph_diags % dndraft % par % mean % q_cl                            &
+                                % request % x_y_z = .true.
+        comorph_diags % dndraft % par % mean % q_cl                            &
+                                % field_3d => mean_qcl_down
+      end if
+      if (.not. associated(par_mean_qcf_up, empty_real_data) ) then
+        allocate(mean_qcf_up(row_length,rows,nlayers))
+        comorph_diags % updraft % par % mean % q_cf                            &
+                                % request % x_y_z = .true.
+        comorph_diags % updraft % par % mean % q_cf                            &
+                                % field_3d => mean_qcf_up
+      end if
+      if (.not. associated(par_mean_qcf_down, empty_real_data) ) then
+        allocate(mean_qcf_down(row_length,rows,nlayers))
+        comorph_diags % dndraft % par % mean % q_cf                            &
+                                % request % x_y_z = .true.
+        comorph_diags % dndraft % par % mean % q_cf                            &
+                                % field_3d => mean_qcf_down
+      end if
+      if (l_cv_rain .and.                                                      &
+          .not. associated(par_mean_qrain_up, empty_real_data) ) then
+        allocate(mean_qrain_up(row_length,rows,nlayers))
+        comorph_diags % updraft % par % mean % q_rain                          &
+                                % request % x_y_z = .true.
+        comorph_diags % updraft % par % mean % q_rain                          &
+                                % field_3d => mean_qrain_up
+      end if
+      if (l_cv_rain .and.                                                      &
+          .not. associated(par_mean_qrain_down, empty_real_data) ) then
+        allocate(mean_qrain_down(row_length,rows,nlayers))
+        comorph_diags % dndraft % par % mean % q_rain                          &
+                                % request % x_y_z = .true.
+        comorph_diags % dndraft % par % mean % q_rain                          &
+                                % field_3d => mean_qrain_down
+      end if
+      if (l_cv_graup .and.                                                     &
+          .not. associated(par_mean_qgraup_up, empty_real_data) ) then
+        allocate(mean_qgraup_up(row_length,rows,nlayers))
+        comorph_diags % updraft % par % mean % q_graup                         &
+                                % request % x_y_z = .true.
+        comorph_diags % updraft % par % mean % q_graup                         &
+                                % field_3d => mean_qgraup_up
+      end if
+      if (l_cv_graup .and.                                                     &
+          .not. associated(par_mean_qgraup_down, empty_real_data) ) then
+        allocate(mean_qgraup_down(row_length,rows,nlayers))
+        comorph_diags % dndraft % par % mean % q_graup                         &
+                                % request % x_y_z = .true.
+        comorph_diags % dndraft % par % mean % q_graup                         &
+                                % field_3d => mean_qgraup_down
+      end if
+      if (l_cv_snow .and.                                                      &
+          .not. associated(par_mean_qsnow_up, empty_real_data) ) then
+        allocate(mean_qsnow_up(row_length,rows,nlayers))
+        comorph_diags % updraft % par % mean % q_snow                          &
+                                % request % x_y_z = .true.
+        comorph_diags % updraft % par % mean % q_snow                          &
+                                % field_3d => mean_qsnow_up
+      end if
+      if (l_cv_snow .and.                                                      &
+          .not. associated(par_mean_qsnow_down, empty_real_data) ) then
+        allocate(mean_qsnow_down(row_length,rows,nlayers))
+        comorph_diags % dndraft % par % mean % q_snow                          &
+                                % request % x_y_z = .true.
+        comorph_diags % dndraft % par % mean % q_snow                          &
+                                % field_3d => mean_qsnow_down
+      end if
+      if (l_cv_cloudfrac .and.                                                 &
+          .not. associated(par_mean_cfl_up, empty_real_data) ) then
+        allocate(mean_cfl_up(row_length,rows,nlayers))
+        comorph_diags % updraft % par % mean % cf_liq                          &
+                                % request % x_y_z = .true.
+        comorph_diags % updraft % par % mean % cf_liq                          &
+                                % field_3d => mean_cfl_up
+      end if
+      if (l_cv_cloudfrac .and.                                                 &
+          .not. associated(par_mean_cfl_down, empty_real_data) ) then
+        allocate(mean_cfl_down(row_length,rows,nlayers))
+        comorph_diags % dndraft % par % mean % cf_liq                          &
+                                % request % x_y_z = .true.
+        comorph_diags % dndraft % par % mean % cf_liq                          &
+                                % field_3d => mean_cfl_down
+      end if
+      if (l_cv_cloudfrac .and.                                                 &
+          .not. associated(par_mean_cff_up, empty_real_data) ) then
+        allocate(mean_cff_up(row_length,rows,nlayers))
+        comorph_diags % updraft % par % mean % cf_ice                          &
+                                % request % x_y_z = .true.
+        comorph_diags % updraft % par % mean % cf_ice                          &
+                                % field_3d => mean_cff_up
+      end if
+      if (l_cv_cloudfrac .and.                                                 &
+          .not. associated(par_mean_cff_down, empty_real_data) ) then
+        allocate(mean_cff_down(row_length,rows,nlayers))
+        comorph_diags % dndraft % par % mean % cf_ice                          &
+                                % request % x_y_z = .true.
+        comorph_diags % dndraft % par % mean % cf_ice                          &
+                                % field_3d => mean_cff_down
+      end if
+      if (l_cv_cloudfrac .and.                                                 &
+          .not. associated(par_mean_cfb_up, empty_real_data) ) then
+        allocate(mean_cfb_up(row_length,rows,nlayers))
+        comorph_diags % updraft % par % mean % cf_bulk                         &
+                                % request % x_y_z = .true.
+        comorph_diags % updraft % par % mean % cf_bulk                         &
+                                % field_3d => mean_cfb_up
+      end if
+      if (l_cv_cloudfrac .and.                                                 &
+          .not. associated(par_mean_cfb_down, empty_real_data) ) then
+        allocate(mean_cfb_down(row_length,rows,nlayers))
+        comorph_diags % dndraft % par % mean % cf_bulk                         &
+                                % request % x_y_z = .true.
+        comorph_diags % dndraft % par % mean % cf_bulk                         &
+                                % field_3d => mean_cfb_down
+      end if
+      if (.not. associated(par_mean_u_up, empty_real_data) ) then
+        allocate(mean_u_up(row_length,rows,nlayers))
+        comorph_diags % updraft % par % mean % wind_u                          &
+                                % request % x_y_z = .true.
+        comorph_diags % updraft % par % mean % wind_u                          &
+                                % field_3d => mean_u_up
+      end if
+      if (.not. associated(par_mean_u_down, empty_real_data) ) then
+        allocate(mean_u_down(row_length,rows,nlayers))
+        comorph_diags % dndraft % par % mean % wind_u                          &
+                                % request % x_y_z = .true.
+        comorph_diags % dndraft % par % mean % wind_u                          &
+                                % field_3d => mean_u_down
+      end if
+      if (.not. associated(par_mean_v_up, empty_real_data) ) then
+        allocate(mean_v_up(row_length,rows,nlayers))
+        comorph_diags % updraft % par % mean % wind_v                          &
+                                % request % x_y_z = .true.
+        comorph_diags % updraft % par % mean % wind_v                          &
+                                % field_3d => mean_v_up
+      end if
+      if (.not. associated(par_mean_v_down, empty_real_data) ) then
+        allocate(mean_v_down(row_length,rows,nlayers))
+        comorph_diags % dndraft % par % mean % wind_v                          &
+                                % request % x_y_z = .true.
+        comorph_diags % dndraft % par % mean % wind_v                          &
+                                % field_3d => mean_v_down
+      end if
+      if (.not. associated(par_mean_w_up, empty_real_data) ) then
+        allocate(mean_w_up(row_length,rows,nlayers))
+        comorph_diags % updraft % par % mean % wind_w                          &
+                                % request % x_y_z = .true.
+        comorph_diags % updraft % par % mean % wind_w                          &
+                                % field_3d => mean_w_up
+      end if
+      if (.not. associated(par_mean_w_down, empty_real_data) ) then
+        allocate(mean_w_down(row_length,rows,nlayers))
+        comorph_diags % dndraft % par % mean % wind_w                          &
+                                % request % x_y_z = .true.
+        comorph_diags % dndraft % par % mean % wind_w                          &
+                                % field_3d => mean_w_down
+      end if
+      if (.not. associated(par_mean_t_up, empty_real_data) ) then
+        allocate(mean_t_up(row_length,rows,nlayers))
+        comorph_diags % updraft % par % mean % temperature                     &
+                                % request % x_y_z = .true.
+        comorph_diags % updraft % par % mean % temperature                     &
+                                % field_3d => mean_t_up
+      end if
+      if (.not. associated(par_mean_t_down, empty_real_data) ) then
+        allocate(mean_t_down(row_length,rows,nlayers))
+        comorph_diags % dndraft % par % mean % temperature                     &
+                                % request % x_y_z = .true.
+        comorph_diags % dndraft % par % mean % temperature                     &
+                                % field_3d => mean_t_down
+      end if
     end if
     if (l_pc2_homog_conv_pressure) then
       allocate(pres_inc_env(row_length,rows,nlayers))
@@ -2682,6 +3038,249 @@ contains
           end do
         end do
         deallocate(rad_down)
+      end if
+
+      ! Copy the mean parcel properties onto rho-levels.  No unit
+      ! conversion is needed for any of these.
+      if (allocated(mean_dtv_up) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_dtv_up(map_w3(1,i) + k-1) = mean_dtv_up(i,1,k)
+          end do
+        end do
+        deallocate(mean_dtv_up)
+      end if
+      if (allocated(mean_dtv_down) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_dtv_down(map_w3(1,i) + k-1) = mean_dtv_down(i,1,k)
+          end do
+        end do
+        deallocate(mean_dtv_down)
+      end if
+      if (allocated(mean_rhl_up) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_rhl_up(map_w3(1,i) + k-1) = mean_rhl_up(i,1,k)
+          end do
+        end do
+        deallocate(mean_rhl_up)
+      end if
+      if (allocated(mean_rhl_down) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_rhl_down(map_w3(1,i) + k-1) = mean_rhl_down(i,1,k)
+          end do
+        end do
+        deallocate(mean_rhl_down)
+      end if
+      if (allocated(mean_q_up) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_q_up(map_w3(1,i) + k-1) = mean_q_up(i,1,k)
+          end do
+        end do
+        deallocate(mean_q_up)
+      end if
+      if (allocated(mean_q_down) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_q_down(map_w3(1,i) + k-1) = mean_q_down(i,1,k)
+          end do
+        end do
+        deallocate(mean_q_down)
+      end if
+      if (allocated(mean_qcl_up) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_qcl_up(map_w3(1,i) + k-1) = mean_qcl_up(i,1,k)
+          end do
+        end do
+        deallocate(mean_qcl_up)
+      end if
+      if (allocated(mean_qcl_down) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_qcl_down(map_w3(1,i) + k-1) = mean_qcl_down(i,1,k)
+          end do
+        end do
+        deallocate(mean_qcl_down)
+      end if
+      if (allocated(mean_qcf_up) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_qcf_up(map_w3(1,i) + k-1) = mean_qcf_up(i,1,k)
+          end do
+        end do
+        deallocate(mean_qcf_up)
+      end if
+      if (allocated(mean_qcf_down) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_qcf_down(map_w3(1,i) + k-1) = mean_qcf_down(i,1,k)
+          end do
+        end do
+        deallocate(mean_qcf_down)
+      end if
+      if (allocated(mean_qrain_up) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_qrain_up(map_w3(1,i) + k-1) = mean_qrain_up(i,1,k)
+          end do
+        end do
+        deallocate(mean_qrain_up)
+      end if
+      if (allocated(mean_qrain_down) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_qrain_down(map_w3(1,i) + k-1) = mean_qrain_down(i,1,k)
+          end do
+        end do
+        deallocate(mean_qrain_down)
+      end if
+      if (allocated(mean_qgraup_up) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_qgraup_up(map_w3(1,i) + k-1) = mean_qgraup_up(i,1,k)
+          end do
+        end do
+        deallocate(mean_qgraup_up)
+      end if
+      if (allocated(mean_qgraup_down) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_qgraup_down(map_w3(1,i) + k-1) = mean_qgraup_down(i,1,k)
+          end do
+        end do
+        deallocate(mean_qgraup_down)
+      end if
+      if (allocated(mean_qsnow_up) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_qsnow_up(map_w3(1,i) + k-1) = mean_qsnow_up(i,1,k)
+          end do
+        end do
+        deallocate(mean_qsnow_up)
+      end if
+      if (allocated(mean_qsnow_down) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_qsnow_down(map_w3(1,i) + k-1) = mean_qsnow_down(i,1,k)
+          end do
+        end do
+        deallocate(mean_qsnow_down)
+      end if
+      if (allocated(mean_cfl_up) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_cfl_up(map_w3(1,i) + k-1) = mean_cfl_up(i,1,k)
+          end do
+        end do
+        deallocate(mean_cfl_up)
+      end if
+      if (allocated(mean_cfl_down) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_cfl_down(map_w3(1,i) + k-1) = mean_cfl_down(i,1,k)
+          end do
+        end do
+        deallocate(mean_cfl_down)
+      end if
+      if (allocated(mean_cff_up) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_cff_up(map_w3(1,i) + k-1) = mean_cff_up(i,1,k)
+          end do
+        end do
+        deallocate(mean_cff_up)
+      end if
+      if (allocated(mean_cff_down) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_cff_down(map_w3(1,i) + k-1) = mean_cff_down(i,1,k)
+          end do
+        end do
+        deallocate(mean_cff_down)
+      end if
+      if (allocated(mean_cfb_up) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_cfb_up(map_w3(1,i) + k-1) = mean_cfb_up(i,1,k)
+          end do
+        end do
+        deallocate(mean_cfb_up)
+      end if
+      if (allocated(mean_cfb_down) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_cfb_down(map_w3(1,i) + k-1) = mean_cfb_down(i,1,k)
+          end do
+        end do
+        deallocate(mean_cfb_down)
+      end if
+      if (allocated(mean_u_up) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_u_up(map_w3(1,i) + k-1) = mean_u_up(i,1,k)
+          end do
+        end do
+        deallocate(mean_u_up)
+      end if
+      if (allocated(mean_u_down) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_u_down(map_w3(1,i) + k-1) = mean_u_down(i,1,k)
+          end do
+        end do
+        deallocate(mean_u_down)
+      end if
+      if (allocated(mean_v_up) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_v_up(map_w3(1,i) + k-1) = mean_v_up(i,1,k)
+          end do
+        end do
+        deallocate(mean_v_up)
+      end if
+      if (allocated(mean_v_down) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_v_down(map_w3(1,i) + k-1) = mean_v_down(i,1,k)
+          end do
+        end do
+        deallocate(mean_v_down)
+      end if
+      if (allocated(mean_w_up) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_w_up(map_w3(1,i) + k-1) = mean_w_up(i,1,k)
+          end do
+        end do
+        deallocate(mean_w_up)
+      end if
+      if (allocated(mean_w_down) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_w_down(map_w3(1,i) + k-1) = mean_w_down(i,1,k)
+          end do
+        end do
+        deallocate(mean_w_down)
+      end if
+      if (allocated(mean_t_up) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_t_up(map_w3(1,i) + k-1) = mean_t_up(i,1,k)
+          end do
+        end do
+        deallocate(mean_t_up)
+      end if
+      if (allocated(mean_t_down) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_mean_t_down(map_w3(1,i) + k-1) = mean_t_down(i,1,k)
+          end do
+        end do
+        deallocate(mean_t_down)
       end if
       ! Frequency of updraught / downdraught on each level.  These use
       ! the CoMorph mass flux before it is modified, so we know the

--- a/interfaces/physics_schemes_interface/source/kernel/conv_comorph_kernel_mod.F90
+++ b/interfaces/physics_schemes_interface/source/kernel/conv_comorph_kernel_mod.F90
@@ -3,6 +3,9 @@
 ! The file LICENCE, distributed with this code, contains details of the terms
 ! under which the code may be used.
 !-----------------------------------------------------------------------------
+! Some of the content of this file has been produced with the assistance of
+! Anthropic Claude Opus 5 (Claude Code).
+!-----------------------------------------------------------------------------
 !> @brief Interface to the Comorph Convection scheme.
 !>
 module conv_comorph_kernel_mod
@@ -33,7 +36,7 @@ module conv_comorph_kernel_mod
   !>
   type, public, extends(kernel_type) :: conv_comorph_kernel_type
     private
-    type(arg_type) :: meta_args(195) = (/                                         &
+    type(arg_type) :: meta_args(197) = (/                                         &
          arg_type(GH_SCALAR, GH_INTEGER, GH_READ),                                &! outer
          arg_type(GH_FIELD,  GH_REAL,    GH_READ,      W3),                       &! rho_in_w3
          arg_type(GH_FIELD,  GH_REAL,    GH_READ,      WTHETA),                   &! rho_in_wth
@@ -228,7 +231,9 @@ module conv_comorph_kernel_mod
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! entrain_down
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! detrain_up
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! detrain_down
-         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3)                        &! massflux_up_half
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! massflux_up_half
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_radius_up
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3)                        &! par_radius_down
         /)
     integer :: operates_on = DOMAIN
   contains
@@ -435,6 +440,8 @@ contains
   !> @param[in,out] detrain_up           Convective upwards detrainment
   !> @param[in,out] detrain_down         Convective downwards detrainment
   !> @param[in,out] massflux_up_half     Convective upwards mass flux on half-levels (Pa/s)
+  !> @param[in,out] par_radius_up        Mean updraught parcel radius on half-levels (m)
+  !> @param[in,out] par_radius_down      Mean downdraught parcel radius on half-levels (m)
   !> @param[in]     ndf_w3               Number of DOFs per cell for density space
   !> @param[in]     undf_w3              Number of unique DOFs  for density space
   !> @param[in]     map_w3               Dofmap for the cell at the base of the column for density space
@@ -646,6 +653,8 @@ contains
                           detrain_up,                        &
                           detrain_down,                      &
                           massflux_up_half,                  &
+                          par_radius_up,                     &
+                          par_radius_down,                   &
                           ndf_w3,                            &
                           undf_w3,                           &
                           map_w3,                            &
@@ -1012,7 +1021,9 @@ contains
                                                 entrain_down(:),     &
                                                 detrain_up(:),       &
                                                 detrain_down(:),     &
-                                                massflux_up_half(:)
+                                                massflux_up_half(:), &
+                                                par_radius_up(:),    &
+                                                par_radius_down(:)
 
     real(kind=r_def), dimension(undf_wth), intent(inout) :: dcfl_conv
     real(kind=r_def), dimension(undf_wth), intent(inout) :: dcff_conv
@@ -1226,7 +1237,7 @@ contains
     real(kind=r_um), target :: up_flux_half(row_length, rows, nlayers)
     real(kind=r_um), target :: down_flux_half(row_length, rows, nlayers)
     real(kind=r_um), target, allocatable, dimension(:,:,:) :: ent_up, ent_down,&
-         det_up, det_down, pres_inc_env
+         det_up, det_down, pres_inc_env, rad_up, rad_down
 
     !-----------------------------------------------------------------------
     ! Mapping of LFRic fields into CoMorph 3D arrays
@@ -2329,6 +2340,22 @@ contains
         comorph_diags % dndraft % plume_model % det_mass_d                     &
                                 % field_3d => det_down
       end if
+      ! Set requests and assign pointers for the mean parcel radius
+      ! diagnostics.  CoMorph calculates these on rho-levels.
+      if (.not. associated(par_radius_up, empty_real_data) ) then
+        allocate(rad_up(row_length,rows,nlayers))
+        comorph_diags % updraft % par % radius                                 &
+                                % request % x_y_z = .true.
+        comorph_diags % updraft % par % radius                                 &
+                                % field_3d => rad_up
+      end if
+      if (.not. associated(par_radius_down, empty_real_data) ) then
+        allocate(rad_down(row_length,rows,nlayers))
+        comorph_diags % dndraft % par % radius                                 &
+                                % request % x_y_z = .true.
+        comorph_diags % dndraft % par % radius                                 &
+                                % field_3d => rad_down
+      end if
     end if
     if (l_pc2_homog_conv_pressure) then
       allocate(pres_inc_env(row_length,rows,nlayers))
@@ -2627,6 +2654,26 @@ contains
           end do
         end do
         deallocate(det_down)
+      end if
+      if (.not. associated(par_radius_up, empty_real_data) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            ! map_w3(1) points to level 1.  The radius is already in m,
+            ! so no conversion is needed.
+            par_radius_up(map_w3(1,i) + k-1) = rad_up(i,1,k)
+          end do
+        end do
+        deallocate(rad_up)
+      end if
+      if (.not. associated(par_radius_down, empty_real_data) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            ! map_w3(1) points to level 1.  The radius is already in m,
+            ! so no conversion is needed.
+            par_radius_down(map_w3(1,i) + k-1) = rad_down(i,1,k)
+          end do
+        end do
+        deallocate(rad_down)
       end if
     end if ! outer_iterations
 

--- a/interfaces/physics_schemes_interface/source/kernel/conv_comorph_kernel_mod.F90
+++ b/interfaces/physics_schemes_interface/source/kernel/conv_comorph_kernel_mod.F90
@@ -36,7 +36,7 @@ module conv_comorph_kernel_mod
   !>
   type, public, extends(kernel_type) :: conv_comorph_kernel_type
     private
-    type(arg_type) :: meta_args(233) = (/                                         &
+    type(arg_type) :: meta_args(239) = (/                                         &
          arg_type(GH_SCALAR, GH_INTEGER, GH_READ),                                &! outer
          arg_type(GH_FIELD,  GH_REAL,    GH_READ,      W3),                       &! rho_in_w3
          arg_type(GH_FIELD,  GH_REAL,    GH_READ,      WTHETA),                   &! rho_in_wth
@@ -269,7 +269,13 @@ module conv_comorph_kernel_mod
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_core_dtv_up
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_core_dtv_down
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_core_rhl_up
-         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3)                        &! par_core_rhl_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_core_rhl_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! turb_pert_u
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! turb_pert_v
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! turb_pert_w
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! turb_pert_t
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! turb_pert_q
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA)                    &! turb_radius
         /)
     integer :: operates_on = DOMAIN
   contains
@@ -514,6 +520,12 @@ contains
   !> @param[in,out] par_core_dtv_down    Downdraught parcel core excess virtual temperature (K)
   !> @param[in,out] par_core_rhl_up      Updraught parcel core relative humidity wrt liquid
   !> @param[in,out] par_core_rhl_down    Downdraught parcel core relative humidity wrt liquid
+  !> @param[in,out] turb_pert_u          Turbulent u wind perturbation (m/s)
+  !> @param[in,out] turb_pert_v          Turbulent v wind perturbation (m/s)
+  !> @param[in,out] turb_pert_w          Turbulent w wind perturbation (m/s)
+  !> @param[in,out] turb_pert_t          Turbulent temperature perturbation (K)
+  !> @param[in,out] turb_pert_q          Turbulent water vapour perturbation (kg/kg)
+  !> @param[in,out] turb_radius          Turbulence-based parcel radius (m)
   !> @param[in]     ndf_w3               Number of DOFs per cell for density space
   !> @param[in]     undf_w3              Number of unique DOFs  for density space
   !> @param[in]     map_w3               Dofmap for the cell at the base of the column for density space
@@ -763,6 +775,12 @@ contains
                           par_core_dtv_down,                 &
                           par_core_rhl_up,                   &
                           par_core_rhl_down,                 &
+                          turb_pert_u,                       &
+                          turb_pert_v,                       &
+                          turb_pert_w,                       &
+                          turb_pert_t,                       &
+                          turb_pert_q,                       &
+                          turb_radius,                       &
                           ndf_w3,                            &
                           undf_w3,                           &
                           map_w3,                            &
@@ -1172,6 +1190,13 @@ contains
                                                 par_core_rhl_up(:),            &
                                                 par_core_rhl_down(:)
 
+    real(kind=r_def), pointer, intent(inout) :: turb_pert_u(:),                &
+                                                turb_pert_v(:),                &
+                                                turb_pert_w(:),                &
+                                                turb_pert_t(:),                &
+                                                turb_pert_q(:),                &
+                                                turb_radius(:)
+
     real(kind=r_def), dimension(undf_wth), intent(inout) :: dcfl_conv
     real(kind=r_def), dimension(undf_wth), intent(inout) :: dcff_conv
     real(kind=r_def), dimension(undf_wth), intent(inout) :: dbcf_conv
@@ -1395,6 +1420,8 @@ contains
          mean_t_up, mean_t_down
     real(kind=r_um), target, allocatable, dimension(:,:,:) ::                  &
          core_dtv_up, core_dtv_down, core_rhl_up, core_rhl_down
+    real(kind=r_um), target, allocatable, dimension(:,:,:) ::                  &
+         tpert_u, tpert_v, tpert_w, tpert_t, tpert_q, trad
 
     !-----------------------------------------------------------------------
     ! Mapping of LFRic fields into CoMorph 3D arrays
@@ -2776,6 +2803,57 @@ contains
         comorph_diags % dndraft % par % core % rel_hum_liq                     &
                                 % field_3d => core_rhl_down
       end if
+
+      ! Set requests and assign pointers for the turbulence diagnostics.
+      ! These are only calculated when turbulence-based parcel generation
+      ! is in use.  The perturbations are on rho-levels, whereas the
+      ! turbulence-based parcel radius is on theta-levels.
+      if (l_turb_par_gen .and.                                                 &
+          .not. associated(turb_pert_u, empty_real_data) ) then
+        allocate(tpert_u(row_length,rows,nlayers))
+        comorph_diags % turb_fields_pert % wind_u                              &
+                                % request % x_y_z = .true.
+        comorph_diags % turb_fields_pert % wind_u                              &
+                                % field_3d => tpert_u
+      end if
+      if (l_turb_par_gen .and.                                                 &
+          .not. associated(turb_pert_v, empty_real_data) ) then
+        allocate(tpert_v(row_length,rows,nlayers))
+        comorph_diags % turb_fields_pert % wind_v                              &
+                                % request % x_y_z = .true.
+        comorph_diags % turb_fields_pert % wind_v                              &
+                                % field_3d => tpert_v
+      end if
+      if (l_turb_par_gen .and.                                                 &
+          .not. associated(turb_pert_w, empty_real_data) ) then
+        allocate(tpert_w(row_length,rows,nlayers))
+        comorph_diags % turb_fields_pert % wind_w                              &
+                                % request % x_y_z = .true.
+        comorph_diags % turb_fields_pert % wind_w                              &
+                                % field_3d => tpert_w
+      end if
+      if (l_turb_par_gen .and.                                                 &
+          .not. associated(turb_pert_t, empty_real_data) ) then
+        allocate(tpert_t(row_length,rows,nlayers))
+        comorph_diags % turb_fields_pert % temperature                         &
+                                % request % x_y_z = .true.
+        comorph_diags % turb_fields_pert % temperature                         &
+                                % field_3d => tpert_t
+      end if
+      if (l_turb_par_gen .and.                                                 &
+          .not. associated(turb_pert_q, empty_real_data) ) then
+        allocate(tpert_q(row_length,rows,nlayers))
+        comorph_diags % turb_fields_pert % q_vap                               &
+                                % request % x_y_z = .true.
+        comorph_diags % turb_fields_pert % q_vap                               &
+                                % field_3d => tpert_q
+      end if
+      if (l_turb_par_gen .and.                                                 &
+          .not. associated(turb_radius, empty_real_data) ) then
+        allocate(trad(row_length,rows,nlayers))
+        comorph_diags % turb_radius % request % x_y_z = .true.
+        comorph_diags % turb_radius % field_3d => trad
+      end if
     end if
     if (l_pc2_homog_conv_pressure) then
       allocate(pres_inc_env(row_length,rows,nlayers))
@@ -3372,6 +3450,57 @@ contains
           end do
         end do
         deallocate(core_rhl_down)
+      end if
+
+      ! Copy the turbulence diagnostics onto their respective levels.
+      ! No unit conversion is needed for any of these.
+      if (allocated(tpert_u) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            turb_pert_u(map_w3(1,i) + k-1) = tpert_u(i,1,k)
+          end do
+        end do
+        deallocate(tpert_u)
+      end if
+      if (allocated(tpert_v) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            turb_pert_v(map_w3(1,i) + k-1) = tpert_v(i,1,k)
+          end do
+        end do
+        deallocate(tpert_v)
+      end if
+      if (allocated(tpert_w) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            turb_pert_w(map_w3(1,i) + k-1) = tpert_w(i,1,k)
+          end do
+        end do
+        deallocate(tpert_w)
+      end if
+      if (allocated(tpert_t) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            turb_pert_t(map_w3(1,i) + k-1) = tpert_t(i,1,k)
+          end do
+        end do
+        deallocate(tpert_t)
+      end if
+      if (allocated(tpert_q) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            turb_pert_q(map_w3(1,i) + k-1) = tpert_q(i,1,k)
+          end do
+        end do
+        deallocate(tpert_q)
+      end if
+      if (allocated(trad) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            turb_radius(map_wth(1,i) + k) = trad(i,1,k)
+          end do
+        end do
+        deallocate(trad)
       end if
       ! Frequency of updraught / downdraught on each level.  These use
       ! the CoMorph mass flux before it is modified, so we know the

--- a/interfaces/physics_schemes_interface/source/kernel/conv_comorph_kernel_mod.F90
+++ b/interfaces/physics_schemes_interface/source/kernel/conv_comorph_kernel_mod.F90
@@ -36,7 +36,7 @@ module conv_comorph_kernel_mod
   !>
   type, public, extends(kernel_type) :: conv_comorph_kernel_type
     private
-    type(arg_type) :: meta_args(229) = (/                                         &
+    type(arg_type) :: meta_args(233) = (/                                         &
          arg_type(GH_SCALAR, GH_INTEGER, GH_READ),                                &! outer
          arg_type(GH_FIELD,  GH_REAL,    GH_READ,      W3),                       &! rho_in_w3
          arg_type(GH_FIELD,  GH_REAL,    GH_READ,      WTHETA),                   &! rho_in_wth
@@ -265,7 +265,11 @@ module conv_comorph_kernel_mod
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_w_up
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_w_down
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_t_up
-         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3)                        &! par_mean_t_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_mean_t_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_core_dtv_up
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_core_dtv_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_core_rhl_up
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3)                        &! par_core_rhl_down
         /)
     integer :: operates_on = DOMAIN
   contains
@@ -506,6 +510,10 @@ contains
   !> @param[in,out] par_mean_w_down      Mean downdraught parcel w wind (m/s)
   !> @param[in,out] par_mean_t_up        Mean updraught parcel temperature (K)
   !> @param[in,out] par_mean_t_down      Mean downdraught parcel temperature (K)
+  !> @param[in,out] par_core_dtv_up      Updraught parcel core excess virtual temperature (K)
+  !> @param[in,out] par_core_dtv_down    Downdraught parcel core excess virtual temperature (K)
+  !> @param[in,out] par_core_rhl_up      Updraught parcel core relative humidity wrt liquid
+  !> @param[in,out] par_core_rhl_down    Downdraught parcel core relative humidity wrt liquid
   !> @param[in]     ndf_w3               Number of DOFs per cell for density space
   !> @param[in]     undf_w3              Number of unique DOFs  for density space
   !> @param[in]     map_w3               Dofmap for the cell at the base of the column for density space
@@ -751,6 +759,10 @@ contains
                           par_mean_w_down,                   &
                           par_mean_t_up,                     &
                           par_mean_t_down,                   &
+                          par_core_dtv_up,                   &
+                          par_core_dtv_down,                 &
+                          par_core_rhl_up,                   &
+                          par_core_rhl_down,                 &
                           ndf_w3,                            &
                           undf_w3,                           &
                           map_w3,                            &
@@ -915,6 +927,7 @@ contains
     use set_constants_from_um_mod, only: set_constants_from_um
     use comorph_constants_mod, only: l_init_constants, l_turb_par_gen,         &
          l_cv_rain, l_cv_cf, l_cv_snow, l_cv_graup, l_cv_cloudfrac,            &
+         l_par_core,                                                          &
          i_convcloud, i_convcloud_liqonly
     use calc_conv_incs_mod, only: calc_conv_incs, i_call_save_before_conv,     &
          i_call_diff_to_get_incs
@@ -1154,6 +1167,11 @@ contains
                                                 par_mean_t_up(:),              &
                                                 par_mean_t_down(:)
 
+    real(kind=r_def), pointer, intent(inout) :: par_core_dtv_up(:),            &
+                                                par_core_dtv_down(:),          &
+                                                par_core_rhl_up(:),            &
+                                                par_core_rhl_down(:)
+
     real(kind=r_def), dimension(undf_wth), intent(inout) :: dcfl_conv
     real(kind=r_def), dimension(undf_wth), intent(inout) :: dcff_conv
     real(kind=r_def), dimension(undf_wth), intent(inout) :: dbcf_conv
@@ -1375,6 +1393,8 @@ contains
          mean_cff_up, mean_cff_down, mean_cfb_up, mean_cfb_down, mean_u_up,    &
          mean_u_down, mean_v_up, mean_v_down, mean_w_up, mean_w_down,          &
          mean_t_up, mean_t_down
+    real(kind=r_um), target, allocatable, dimension(:,:,:) ::                  &
+         core_dtv_up, core_dtv_down, core_rhl_up, core_rhl_down
 
     !-----------------------------------------------------------------------
     ! Mapping of LFRic fields into CoMorph 3D arrays
@@ -2720,6 +2740,42 @@ contains
         comorph_diags % dndraft % par % mean % temperature                     &
                                 % field_3d => mean_t_down
       end if
+
+      ! Set requests and assign pointers for the parcel core property
+      ! diagnostics.  These only exist when the parcel core properties
+      ! are in use.
+      if (l_par_core .and.                                                     &
+          .not. associated(par_core_dtv_up, empty_real_data) ) then
+        allocate(core_dtv_up(row_length,rows,nlayers))
+        comorph_diags % updraft % par % core % virt_temp_excess                &
+                                % request % x_y_z = .true.
+        comorph_diags % updraft % par % core % virt_temp_excess                &
+                                % field_3d => core_dtv_up
+      end if
+      if (l_par_core .and.                                                     &
+          .not. associated(par_core_dtv_down, empty_real_data) ) then
+        allocate(core_dtv_down(row_length,rows,nlayers))
+        comorph_diags % dndraft % par % core % virt_temp_excess                &
+                                % request % x_y_z = .true.
+        comorph_diags % dndraft % par % core % virt_temp_excess                &
+                                % field_3d => core_dtv_down
+      end if
+      if (l_par_core .and.                                                     &
+          .not. associated(par_core_rhl_up, empty_real_data) ) then
+        allocate(core_rhl_up(row_length,rows,nlayers))
+        comorph_diags % updraft % par % core % rel_hum_liq                     &
+                                % request % x_y_z = .true.
+        comorph_diags % updraft % par % core % rel_hum_liq                     &
+                                % field_3d => core_rhl_up
+      end if
+      if (l_par_core .and.                                                     &
+          .not. associated(par_core_rhl_down, empty_real_data) ) then
+        allocate(core_rhl_down(row_length,rows,nlayers))
+        comorph_diags % dndraft % par % core % rel_hum_liq                     &
+                                % request % x_y_z = .true.
+        comorph_diags % dndraft % par % core % rel_hum_liq                     &
+                                % field_3d => core_rhl_down
+      end if
     end if
     if (l_pc2_homog_conv_pressure) then
       allocate(pres_inc_env(row_length,rows,nlayers))
@@ -3281,6 +3337,41 @@ contains
           end do
         end do
         deallocate(mean_t_down)
+      end if
+
+      ! Copy the parcel core properties onto rho-levels.  No unit
+      ! conversion is needed for either of these.
+      if (allocated(core_dtv_up) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_core_dtv_up(map_w3(1,i) + k-1) = core_dtv_up(i,1,k)
+          end do
+        end do
+        deallocate(core_dtv_up)
+      end if
+      if (allocated(core_dtv_down) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_core_dtv_down(map_w3(1,i) + k-1) = core_dtv_down(i,1,k)
+          end do
+        end do
+        deallocate(core_dtv_down)
+      end if
+      if (allocated(core_rhl_up) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_core_rhl_up(map_w3(1,i) + k-1) = core_rhl_up(i,1,k)
+          end do
+        end do
+        deallocate(core_rhl_up)
+      end if
+      if (allocated(core_rhl_down) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            par_core_rhl_down(map_w3(1,i) + k-1) = core_rhl_down(i,1,k)
+          end do
+        end do
+        deallocate(core_rhl_down)
       end if
       ! Frequency of updraught / downdraught on each level.  These use
       ! the CoMorph mass flux before it is modified, so we know the

--- a/interfaces/physics_schemes_interface/source/kernel/conv_comorph_kernel_mod.F90
+++ b/interfaces/physics_schemes_interface/source/kernel/conv_comorph_kernel_mod.F90
@@ -36,7 +36,7 @@ module conv_comorph_kernel_mod
   !>
   type, public, extends(kernel_type) :: conv_comorph_kernel_type
     private
-    type(arg_type) :: meta_args(239) = (/                                         &
+    type(arg_type) :: meta_args(256) = (/                                         &
          arg_type(GH_SCALAR, GH_INTEGER, GH_READ),                                &! outer
          arg_type(GH_FIELD,  GH_REAL,    GH_READ,      W3),                       &! rho_in_w3
          arg_type(GH_FIELD,  GH_REAL,    GH_READ,      WTHETA),                   &! rho_in_wth
@@ -275,7 +275,24 @@ module conv_comorph_kernel_mod
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! turb_pert_w
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! turb_pert_t
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! turb_pert_q
-         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA)                    &! turb_radius
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! turb_radius
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! subreg_dry_frac
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! subreg_liq_frac
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! subreg_mph_frac
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! subreg_icr_frac
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! subreg_dry_t
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! subreg_liq_t
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! subreg_mph_t
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! subreg_icr_t
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! subreg_dry_q
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! subreg_liq_q
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! subreg_mph_q
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! subreg_icr_q
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! subreg_dry_rhl
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! subreg_liq_rhl
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! subreg_mph_rhl
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! subreg_icr_rhl
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3)                        &! massflux_down_half
         /)
     integer :: operates_on = DOMAIN
   contains
@@ -526,6 +543,23 @@ contains
   !> @param[in,out] turb_pert_t          Turbulent temperature perturbation (K)
   !> @param[in,out] turb_pert_q          Turbulent water vapour perturbation (kg/kg)
   !> @param[in,out] turb_radius          Turbulence-based parcel radius (m)
+  !> @param[in,out] subreg_dry_frac      Clear-sky sub-region area fraction
+  !> @param[in,out] subreg_liq_frac      Liquid-cloud sub-region area fraction
+  !> @param[in,out] subreg_mph_frac      Mixed-phase sub-region area fraction
+  !> @param[in,out] subreg_icr_frac      Ice/rain sub-region area fraction
+  !> @param[in,out] subreg_dry_t         Clear-sky sub-region temperature (K)
+  !> @param[in,out] subreg_liq_t         Liquid-cloud sub-region temperature (K)
+  !> @param[in,out] subreg_mph_t         Mixed-phase sub-region temperature (K)
+  !> @param[in,out] subreg_icr_t         Ice/rain sub-region temperature (K)
+  !> @param[in,out] subreg_dry_q         Clear-sky sub-region water vapour (kg/kg)
+  !> @param[in,out] subreg_liq_q         Liquid-cloud sub-region water vapour (kg/kg)
+  !> @param[in,out] subreg_mph_q         Mixed-phase sub-region water vapour (kg/kg)
+  !> @param[in,out] subreg_icr_q         Ice/rain sub-region water vapour (kg/kg)
+  !> @param[in,out] subreg_dry_rhl       Clear-sky sub-region relative humidity wrt liquid
+  !> @param[in,out] subreg_liq_rhl       Liquid-cloud sub-region relative humidity wrt liquid
+  !> @param[in,out] subreg_mph_rhl       Mixed-phase sub-region relative humidity wrt liquid
+  !> @param[in,out] subreg_icr_rhl       Ice/rain sub-region relative humidity wrt liquid
+  !> @param[in,out] massflux_down_half   Convective downwards mass flux on half-levels (Pa/s)
   !> @param[in]     ndf_w3               Number of DOFs per cell for density space
   !> @param[in]     undf_w3              Number of unique DOFs  for density space
   !> @param[in]     map_w3               Dofmap for the cell at the base of the column for density space
@@ -781,6 +815,23 @@ contains
                           turb_pert_t,                       &
                           turb_pert_q,                       &
                           turb_radius,                       &
+                          subreg_dry_frac,                   &
+                          subreg_liq_frac,                   &
+                          subreg_mph_frac,                   &
+                          subreg_icr_frac,                   &
+                          subreg_dry_t,                      &
+                          subreg_liq_t,                      &
+                          subreg_mph_t,                      &
+                          subreg_icr_t,                      &
+                          subreg_dry_q,                      &
+                          subreg_liq_q,                      &
+                          subreg_mph_q,                      &
+                          subreg_icr_q,                      &
+                          subreg_dry_rhl,                    &
+                          subreg_liq_rhl,                    &
+                          subreg_mph_rhl,                    &
+                          subreg_icr_rhl,                    &
+                          massflux_down_half,                &
                           ndf_w3,                            &
                           undf_w3,                           &
                           map_w3,                            &
@@ -942,6 +993,7 @@ contains
     use turb_type_mod, only: turb_type, turb_nullify
     use cloudfracs_type_mod, only: cloudfracs_type, cloudfracs_nullify
     use comorph_diags_type_mod, only: comorph_diags_type
+    use subregion_mod, only: i_dry, i_liq, i_mph, i_icr
     use set_constants_from_um_mod, only: set_constants_from_um
     use comorph_constants_mod, only: l_init_constants, l_turb_par_gen,         &
          l_cv_rain, l_cv_cf, l_cv_snow, l_cv_graup, l_cv_cloudfrac,            &
@@ -1197,6 +1249,25 @@ contains
                                                 turb_pert_q(:),                &
                                                 turb_radius(:)
 
+    real(kind=r_def), pointer, intent(inout) :: subreg_dry_frac(:),            &
+                                                subreg_liq_frac(:),            &
+                                                subreg_mph_frac(:),            &
+                                                subreg_icr_frac(:),            &
+                                                subreg_dry_t(:),               &
+                                                subreg_liq_t(:),               &
+                                                subreg_mph_t(:),               &
+                                                subreg_icr_t(:),               &
+                                                subreg_dry_q(:),               &
+                                                subreg_liq_q(:),               &
+                                                subreg_mph_q(:),               &
+                                                subreg_icr_q(:),               &
+                                                subreg_dry_rhl(:),             &
+                                                subreg_liq_rhl(:),             &
+                                                subreg_mph_rhl(:),             &
+                                                subreg_icr_rhl(:)
+
+    real(kind=r_def), pointer, intent(inout) :: massflux_down_half(:)
+
     real(kind=r_def), dimension(undf_wth), intent(inout) :: dcfl_conv
     real(kind=r_def), dimension(undf_wth), intent(inout) :: dcff_conv
     real(kind=r_def), dimension(undf_wth), intent(inout) :: dbcf_conv
@@ -1422,6 +1493,11 @@ contains
          core_dtv_up, core_dtv_down, core_rhl_up, core_rhl_down
     real(kind=r_um), target, allocatable, dimension(:,:,:) ::                  &
          tpert_u, tpert_v, tpert_w, tpert_t, tpert_q, trad
+    real(kind=r_um), target, allocatable, dimension(:,:,:) ::                  &
+         sreg_dry_frac, sreg_liq_frac, sreg_mph_frac, sreg_icr_frac,           &
+         sreg_dry_t, sreg_liq_t, sreg_mph_t, sreg_icr_t,                       &
+         sreg_dry_q, sreg_liq_q, sreg_mph_q, sreg_icr_q,                       &
+         sreg_dry_rhl, sreg_liq_rhl, sreg_mph_rhl, sreg_icr_rhl
 
     !-----------------------------------------------------------------------
     ! Mapping of LFRic fields into CoMorph 3D arrays
@@ -2854,6 +2930,118 @@ contains
         comorph_diags % turb_radius % request % x_y_z = .true.
         comorph_diags % turb_radius % field_3d => trad
       end if
+      if (.not. associated(subreg_dry_frac, empty_real_data) ) then
+        allocate(sreg_dry_frac(row_length,rows,nlayers))
+        comorph_diags % genesis_diags % subregion_diags(i_dry) % frac          &
+                                % request % x_y_z = .true.
+        comorph_diags % genesis_diags % subregion_diags(i_dry) % frac          &
+                                % field_3d => sreg_dry_frac
+      end if
+      if (.not. associated(subreg_liq_frac, empty_real_data) ) then
+        allocate(sreg_liq_frac(row_length,rows,nlayers))
+        comorph_diags % genesis_diags % subregion_diags(i_liq) % frac          &
+                                % request % x_y_z = .true.
+        comorph_diags % genesis_diags % subregion_diags(i_liq) % frac          &
+                                % field_3d => sreg_liq_frac
+      end if
+      if (.not. associated(subreg_mph_frac, empty_real_data) ) then
+        allocate(sreg_mph_frac(row_length,rows,nlayers))
+        comorph_diags % genesis_diags % subregion_diags(i_mph) % frac          &
+                                % request % x_y_z = .true.
+        comorph_diags % genesis_diags % subregion_diags(i_mph) % frac          &
+                                % field_3d => sreg_mph_frac
+      end if
+      if (.not. associated(subreg_icr_frac, empty_real_data) ) then
+        allocate(sreg_icr_frac(row_length,rows,nlayers))
+        comorph_diags % genesis_diags % subregion_diags(i_icr) % frac          &
+                                % request % x_y_z = .true.
+        comorph_diags % genesis_diags % subregion_diags(i_icr) % frac          &
+                                % field_3d => sreg_icr_frac
+      end if
+      if (.not. associated(subreg_dry_t, empty_real_data) ) then
+        allocate(sreg_dry_t(row_length,rows,nlayers))
+        comorph_diags % genesis_diags % subregion_diags(i_dry) % fields        &
+                                % temperature % request % x_y_z = .true.
+        comorph_diags % genesis_diags % subregion_diags(i_dry) % fields        &
+                                % temperature % field_3d => sreg_dry_t
+      end if
+      if (.not. associated(subreg_liq_t, empty_real_data) ) then
+        allocate(sreg_liq_t(row_length,rows,nlayers))
+        comorph_diags % genesis_diags % subregion_diags(i_liq) % fields        &
+                                % temperature % request % x_y_z = .true.
+        comorph_diags % genesis_diags % subregion_diags(i_liq) % fields        &
+                                % temperature % field_3d => sreg_liq_t
+      end if
+      if (.not. associated(subreg_mph_t, empty_real_data) ) then
+        allocate(sreg_mph_t(row_length,rows,nlayers))
+        comorph_diags % genesis_diags % subregion_diags(i_mph) % fields        &
+                                % temperature % request % x_y_z = .true.
+        comorph_diags % genesis_diags % subregion_diags(i_mph) % fields        &
+                                % temperature % field_3d => sreg_mph_t
+      end if
+      if (.not. associated(subreg_icr_t, empty_real_data) ) then
+        allocate(sreg_icr_t(row_length,rows,nlayers))
+        comorph_diags % genesis_diags % subregion_diags(i_icr) % fields        &
+                                % temperature % request % x_y_z = .true.
+        comorph_diags % genesis_diags % subregion_diags(i_icr) % fields        &
+                                % temperature % field_3d => sreg_icr_t
+      end if
+      if (.not. associated(subreg_dry_q, empty_real_data) ) then
+        allocate(sreg_dry_q(row_length,rows,nlayers))
+        comorph_diags % genesis_diags % subregion_diags(i_dry) % fields        &
+                                % q_vap % request % x_y_z = .true.
+        comorph_diags % genesis_diags % subregion_diags(i_dry) % fields        &
+                                % q_vap % field_3d => sreg_dry_q
+      end if
+      if (.not. associated(subreg_liq_q, empty_real_data) ) then
+        allocate(sreg_liq_q(row_length,rows,nlayers))
+        comorph_diags % genesis_diags % subregion_diags(i_liq) % fields        &
+                                % q_vap % request % x_y_z = .true.
+        comorph_diags % genesis_diags % subregion_diags(i_liq) % fields        &
+                                % q_vap % field_3d => sreg_liq_q
+      end if
+      if (.not. associated(subreg_mph_q, empty_real_data) ) then
+        allocate(sreg_mph_q(row_length,rows,nlayers))
+        comorph_diags % genesis_diags % subregion_diags(i_mph) % fields        &
+                                % q_vap % request % x_y_z = .true.
+        comorph_diags % genesis_diags % subregion_diags(i_mph) % fields        &
+                                % q_vap % field_3d => sreg_mph_q
+      end if
+      if (.not. associated(subreg_icr_q, empty_real_data) ) then
+        allocate(sreg_icr_q(row_length,rows,nlayers))
+        comorph_diags % genesis_diags % subregion_diags(i_icr) % fields        &
+                                % q_vap % request % x_y_z = .true.
+        comorph_diags % genesis_diags % subregion_diags(i_icr) % fields        &
+                                % q_vap % field_3d => sreg_icr_q
+      end if
+      if (.not. associated(subreg_dry_rhl, empty_real_data) ) then
+        allocate(sreg_dry_rhl(row_length,rows,nlayers))
+        comorph_diags % genesis_diags % subregion_diags(i_dry) % fields        &
+                                % rel_hum_liq % request % x_y_z = .true.
+        comorph_diags % genesis_diags % subregion_diags(i_dry) % fields        &
+                                % rel_hum_liq % field_3d => sreg_dry_rhl
+      end if
+      if (.not. associated(subreg_liq_rhl, empty_real_data) ) then
+        allocate(sreg_liq_rhl(row_length,rows,nlayers))
+        comorph_diags % genesis_diags % subregion_diags(i_liq) % fields        &
+                                % rel_hum_liq % request % x_y_z = .true.
+        comorph_diags % genesis_diags % subregion_diags(i_liq) % fields        &
+                                % rel_hum_liq % field_3d => sreg_liq_rhl
+      end if
+      if (.not. associated(subreg_mph_rhl, empty_real_data) ) then
+        allocate(sreg_mph_rhl(row_length,rows,nlayers))
+        comorph_diags % genesis_diags % subregion_diags(i_mph) % fields        &
+                                % rel_hum_liq % request % x_y_z = .true.
+        comorph_diags % genesis_diags % subregion_diags(i_mph) % fields        &
+                                % rel_hum_liq % field_3d => sreg_mph_rhl
+      end if
+      if (.not. associated(subreg_icr_rhl, empty_real_data) ) then
+        allocate(sreg_icr_rhl(row_length,rows,nlayers))
+        comorph_diags % genesis_diags % subregion_diags(i_icr) % fields        &
+                                % rel_hum_liq % request % x_y_z = .true.
+        comorph_diags % genesis_diags % subregion_diags(i_icr) % fields        &
+                                % rel_hum_liq % field_3d => sreg_icr_rhl
+      end if
     end if
     if (l_pc2_homog_conv_pressure) then
       allocate(pres_inc_env(row_length,rows,nlayers))
@@ -3501,6 +3689,143 @@ contains
           end do
         end do
         deallocate(trad)
+      end if
+      if (allocated(sreg_dry_frac) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            subreg_dry_frac(map_wth(1,i) + k) = sreg_dry_frac(i,1,k)
+          end do
+        end do
+        deallocate(sreg_dry_frac)
+      end if
+      if (allocated(sreg_liq_frac) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            subreg_liq_frac(map_wth(1,i) + k) = sreg_liq_frac(i,1,k)
+          end do
+        end do
+        deallocate(sreg_liq_frac)
+      end if
+      if (allocated(sreg_mph_frac) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            subreg_mph_frac(map_wth(1,i) + k) = sreg_mph_frac(i,1,k)
+          end do
+        end do
+        deallocate(sreg_mph_frac)
+      end if
+      if (allocated(sreg_icr_frac) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            subreg_icr_frac(map_wth(1,i) + k) = sreg_icr_frac(i,1,k)
+          end do
+        end do
+        deallocate(sreg_icr_frac)
+      end if
+      if (allocated(sreg_dry_t) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            subreg_dry_t(map_wth(1,i) + k) = sreg_dry_t(i,1,k)
+          end do
+        end do
+        deallocate(sreg_dry_t)
+      end if
+      if (allocated(sreg_liq_t) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            subreg_liq_t(map_wth(1,i) + k) = sreg_liq_t(i,1,k)
+          end do
+        end do
+        deallocate(sreg_liq_t)
+      end if
+      if (allocated(sreg_mph_t) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            subreg_mph_t(map_wth(1,i) + k) = sreg_mph_t(i,1,k)
+          end do
+        end do
+        deallocate(sreg_mph_t)
+      end if
+      if (allocated(sreg_icr_t) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            subreg_icr_t(map_wth(1,i) + k) = sreg_icr_t(i,1,k)
+          end do
+        end do
+        deallocate(sreg_icr_t)
+      end if
+      if (allocated(sreg_dry_q) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            subreg_dry_q(map_wth(1,i) + k) = sreg_dry_q(i,1,k)
+          end do
+        end do
+        deallocate(sreg_dry_q)
+      end if
+      if (allocated(sreg_liq_q) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            subreg_liq_q(map_wth(1,i) + k) = sreg_liq_q(i,1,k)
+          end do
+        end do
+        deallocate(sreg_liq_q)
+      end if
+      if (allocated(sreg_mph_q) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            subreg_mph_q(map_wth(1,i) + k) = sreg_mph_q(i,1,k)
+          end do
+        end do
+        deallocate(sreg_mph_q)
+      end if
+      if (allocated(sreg_icr_q) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            subreg_icr_q(map_wth(1,i) + k) = sreg_icr_q(i,1,k)
+          end do
+        end do
+        deallocate(sreg_icr_q)
+      end if
+      if (allocated(sreg_dry_rhl) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            subreg_dry_rhl(map_wth(1,i) + k) = sreg_dry_rhl(i,1,k)
+          end do
+        end do
+        deallocate(sreg_dry_rhl)
+      end if
+      if (allocated(sreg_liq_rhl) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            subreg_liq_rhl(map_wth(1,i) + k) = sreg_liq_rhl(i,1,k)
+          end do
+        end do
+        deallocate(sreg_liq_rhl)
+      end if
+      if (allocated(sreg_mph_rhl) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            subreg_mph_rhl(map_wth(1,i) + k) = sreg_mph_rhl(i,1,k)
+          end do
+        end do
+        deallocate(sreg_mph_rhl)
+      end if
+      if (allocated(sreg_icr_rhl) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            subreg_icr_rhl(map_wth(1,i) + k) = sreg_icr_rhl(i,1,k)
+          end do
+        end do
+        deallocate(sreg_icr_rhl)
+      end if
+      ! Downdraught mass flux on rho levels.  Scale by g to convert
+      ! to Pa s-1.
+      if (.not. associated(massflux_down_half, empty_real_data) ) then
+        do k = 1, nlayers
+          do i = 1, row_length
+            massflux_down_half(map_w3(1,i) + k-1) = down_flux_half(i,1,k) * g
+          end do
+        end do
       end if
       ! Frequency of updraught / downdraught on each level.  These use
       ! the CoMorph mass flux before it is modified, so we know the

--- a/interfaces/physics_schemes_interface/source/kernel/conv_comorph_kernel_mod.F90
+++ b/interfaces/physics_schemes_interface/source/kernel/conv_comorph_kernel_mod.F90
@@ -2613,32 +2613,6 @@ contains
       end do
     end do
 
-    ! Frequency of updraught / downdraught on each level.  These use the
-    ! CoMorph mass flux before it is modified, so we know the complete set
-    ! of levels with non-zero values.
-    if (.not. associated(freq_up, empty_real_data) ) then
-      do k = 1, n_conv_levels
-        do i = 1, row_length
-          if (up_flux_half(i,1,k) > 0.0_r_um) then
-            freq_up(map_w3(1,i) + k-1) = 1.0_r_def
-          else
-            freq_up(map_w3(1,i) + k-1) = 0.0_r_def
-          end if
-        end do
-      end do
-    end if
-    if (.not. associated(freq_down, empty_real_data) ) then
-      do k = 1, n_conv_levels
-        do i = 1, row_length
-          if (down_flux_half(i,1,k) > 0.0_r_um) then
-            freq_down(map_w3(1,i) + k-1) = 1.0_r_def
-          else
-            freq_down(map_w3(1,i) + k-1) = 0.0_r_def
-          end if
-        end do
-      end do
-    end if
-
     if (l_pc2_homog_conv_pressure) then
       do k = 1, n_conv_levels
         do i = 1, row_length
@@ -2708,6 +2682,31 @@ contains
           end do
         end do
         deallocate(rad_down)
+      end if
+      ! Frequency of updraught / downdraught on each level.  These use
+      ! the CoMorph mass flux before it is modified, so we know the
+      ! complete set of levels with non-zero values.
+      if (.not. associated(freq_up, empty_real_data) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            if (up_flux_half(i,1,k) > 0.0_r_um) then
+              freq_up(map_w3(1,i) + k-1) = 1.0_r_def
+            else
+              freq_up(map_w3(1,i) + k-1) = 0.0_r_def
+            end if
+          end do
+        end do
+      end if
+      if (.not. associated(freq_down, empty_real_data) ) then
+        do k = 1, n_conv_levels
+          do i = 1, row_length
+            if (down_flux_half(i,1,k) > 0.0_r_um) then
+              freq_down(map_w3(1,i) + k-1) = 1.0_r_def
+            else
+              freq_down(map_w3(1,i) + k-1) = 0.0_r_def
+            end if
+          end do
+        end do
       end if
     end if ! outer_iterations
 

--- a/interfaces/physics_schemes_interface/source/kernel/conv_comorph_kernel_mod.F90
+++ b/interfaces/physics_schemes_interface/source/kernel/conv_comorph_kernel_mod.F90
@@ -36,7 +36,7 @@ module conv_comorph_kernel_mod
   !>
   type, public, extends(kernel_type) :: conv_comorph_kernel_type
     private
-    type(arg_type) :: meta_args(197) = (/                                         &
+    type(arg_type) :: meta_args(199) = (/                                         &
          arg_type(GH_SCALAR, GH_INTEGER, GH_READ),                                &! outer
          arg_type(GH_FIELD,  GH_REAL,    GH_READ,      W3),                       &! rho_in_w3
          arg_type(GH_FIELD,  GH_REAL,    GH_READ,      WTHETA),                   &! rho_in_wth
@@ -233,7 +233,9 @@ module conv_comorph_kernel_mod
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, WTHETA),                   &! detrain_down
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! massflux_up_half
          arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_radius_up
-         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3)                        &! par_radius_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! par_radius_down
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3),                       &! freq_up
+         arg_type(GH_FIELD,  GH_REAL,    GH_READWRITE, W3)                        &! freq_down
         /)
     integer :: operates_on = DOMAIN
   contains
@@ -442,6 +444,8 @@ contains
   !> @param[in,out] massflux_up_half     Convective upwards mass flux on half-levels (Pa/s)
   !> @param[in,out] par_radius_up        Mean updraught parcel radius on half-levels (m)
   !> @param[in,out] par_radius_down      Mean downdraught parcel radius on half-levels (m)
+  !> @param[in,out] freq_up              Frequency of updraught on half-levels
+  !> @param[in,out] freq_down            Frequency of downdraught on half-levels
   !> @param[in]     ndf_w3               Number of DOFs per cell for density space
   !> @param[in]     undf_w3              Number of unique DOFs  for density space
   !> @param[in]     map_w3               Dofmap for the cell at the base of the column for density space
@@ -655,6 +659,8 @@ contains
                           massflux_up_half,                  &
                           par_radius_up,                     &
                           par_radius_down,                   &
+                          freq_up,                           &
+                          freq_down,                         &
                           ndf_w3,                            &
                           undf_w3,                           &
                           map_w3,                            &
@@ -1023,7 +1029,9 @@ contains
                                                 detrain_down(:),     &
                                                 massflux_up_half(:), &
                                                 par_radius_up(:),    &
-                                                par_radius_down(:)
+                                                par_radius_down(:),  &
+                                                freq_up(:),          &
+                                                freq_down(:)
 
     real(kind=r_def), dimension(undf_wth), intent(inout) :: dcfl_conv
     real(kind=r_def), dimension(undf_wth), intent(inout) :: dcff_conv
@@ -2604,6 +2612,32 @@ contains
                                     +  interp  * down_flux_half(i,1,k+1) * g
       end do
     end do
+
+    ! Frequency of updraught / downdraught on each level.  These use the
+    ! CoMorph mass flux before it is modified, so we know the complete set
+    ! of levels with non-zero values.
+    if (.not. associated(freq_up, empty_real_data) ) then
+      do k = 1, n_conv_levels
+        do i = 1, row_length
+          if (up_flux_half(i,1,k) > 0.0_r_um) then
+            freq_up(map_w3(1,i) + k-1) = 1.0_r_def
+          else
+            freq_up(map_w3(1,i) + k-1) = 0.0_r_def
+          end if
+        end do
+      end do
+    end if
+    if (.not. associated(freq_down, empty_real_data) ) then
+      do k = 1, n_conv_levels
+        do i = 1, row_length
+          if (down_flux_half(i,1,k) > 0.0_r_um) then
+            freq_down(map_w3(1,i) + k-1) = 1.0_r_def
+          else
+            freq_down(map_w3(1,i) + k-1) = 0.0_r_def
+          end if
+        end do
+      end do
+    end if
 
     if (l_pc2_homog_conv_pressure) then
       do k = 1, n_conv_levels


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: <!-- SR id, filled by author when ready for review (e.g. @octocat) -->
Code Reviewer: <!-- CR id, filled by SSD/CCD (e.g. @octocat) -->

<!-- To be completed by the developer -->

All Comorph diagnostics which have equivalent UM stashcodes:
| STASH | UM name | LFRic diagnostic | | Notes |
| --- | --- | --- | :-: | :-: |
| `5-550` | average updraught parcel radius (m) | `convection__par_radius_up` | D | #692 |
| `5-551` | average downdraught parcel radius(m) | `convection__par_radius_down` | D | #692 |
| `5-552` | Frequency of updraught on level | `convection__freq_up` | D | #692 |
| `5-553` | Frequency of downdraught on level | `convection__freq_down` | D | #692 |
| `5-554` | Up parcel mean virt temp excess  (K) | `convection__par_mean_dtv_up` | D | #692 |
| `5-555` | Down parcel mean virt temp excess(K) | `convection__par_mean_dtv_down` | D | #692 |
| `5-556` | Up parcel mean relative humidity | `convection__par_mean_rhl_up` | D | #692 |
| `5-557` | Down parcel mean relative humidity | `convection__par_mean_rhl_down` | D | #692 |
| `5-558` | Up parcel mean water vapour (kg/kg) | `convection__par_mean_q_up` | D | #692 |
| `5-559` | Down parcel mean water vapour(kg/kg) | `convection__par_mean_q_down` | D | #692 |
| `5-560` | Up parcel mean liq cld water (kg/kg) | `convection__par_mean_qcl_up` | D | #692 |
| `5-561` | Down par mean liq cld water  (kg/kg) | `convection__par_mean_qcl_down` | D | #692 |
| `5-562` | Up parcel mean ice cld water (kg/kg) | `convection__par_mean_qcf_up` | D | #692 |
| `5-563` | Down par mean ice cld water  (kg/kg) | `convection__par_mean_qcf_down` | D | #692 |
| `5-564` | Up parcel mean rain water    (kg/kg) | `convection__par_mean_qrain_up` | D | #692 |
| `5-565` | Down parcel mean rain water  (kg/kg) | `convection__par_mean_qrain_down` | D | #692 |
| `5-566` | Up parcel mean graupel       (kg/kg) | `convection__par_mean_qgraup_up` | D | #692 |
| `5-567` | Down parcel mean graupel     (kg/kg) | `convection__par_mean_qgraup_down` | D | #692 |
| `5-568` | Up parcel mean snow water    (kg/kg) | `convection__par_mean_qsnow_up` | D | #692 |
| `5-569` | Down parcel mean snow water  (kg/kg) | `convection__par_mean_qsnow_down` | D | #692 |
| `5-570` | Up parcel mean cloud liq fraction | `convection__par_mean_cfl_up` | D | #692 |
| `5-571` | Down parcel mean cloud liq fraction | `convection__par_mean_cfl_down` | D | #692 |
| `5-572` | Up parcel mean cloud ice fraction | `convection__par_mean_cff_up` | D | #692 |
| `5-573` | Down parcel mean cloud ice fraction | `convection__par_mean_cff_down` | D | #692 |
| `5-574` | Up parcel mean cloud bulk fraction | `convection__par_mean_cfb_up` | D | #692 |
| `5-575` | Down parcel mean cloud bulk fraction | `convection__par_mean_cfb_down` | D | #692 |
| `5-576` | Up parcel mean u wind  (m/s) | `convection__par_mean_u_up` | D | #692 |
| `5-577` | Down parcel mean u wind  (m/s) | `convection__par_mean_u_down` | D | #692 |
| `5-578` | Up parcel mean v wind  (m/s) | `convection__par_mean_v_up` | D | #692 |
| `5-579` | Down parcel mean v wind  (m/s) | `convection__par_mean_v_down` | D | #692 |
| `5-580` | Up parcel mean w wind  (m/s) | `convection__par_mean_w_up` | D | #692 |
| `5-581` | Down parcel mean w wind  (m/s) | `convection__par_mean_w_down` | D | #692 |
| `5-582` | Up parcel mean temperature (K) | `convection__par_mean_t_up` | D | #692 |
| `5-583` | Down parcel mean  temperature (K) | `convection__par_mean_t_down` | D | #692 |
| `5-584` | Up parcel core virt temp excess  (K) | `convection__par_core_dtv_up` | D | #692 |
| `5-585` | Down parcel core virt temp excess(K) | `convection__par_core_dtv_down` | D | #692 |
| `5-586` | Up parcel core relative humidity | `convection__par_core_rhl_up` | D | #692 |
| `5-587` | Down parcel core relative humidity | `convection__par_core_rhl_down` | D | #692 |
| `5-594` | Turbulent u wind perturbation (m/s) | `convection__turb_pert_u` | D | #692 |
| `5-595` | Turbulent v wind perturbation (m/s) | `convection__turb_pert_v` | D | #692 |
| `5-596` | Turbulent w wind perturbation (m/s) | `convection__turb_pert_w` | D | #692 |
| `5-597` | Turbulent temperature perturb   (K) | `convection__turb_pert_t` | D | #692 |
| `5-598` | Turbulent water vapour pert  (kg/kg) | `convection__turb_pert_q` | D | #692 |
| `5-599` | Turbulent radius               (m) | `convection__turb_radius` | D | #692 |
| `5-600` | Fraction of dry sub region gridbox | `convection__subreg_dry_frac` | D | #692 |
| `5-601` | Fraction of liq sub region gridbox | `convection__subreg_liq_frac` | D | #692 |
| `5-602` | Fraction of mixed phase sub region | `convection__subreg_mph_frac` | D | #692 |
| `5-603` | Fraction of ice rain sub region | `convection__subreg_icr_frac` | D | #692 |
| `5-604` | Temperature of dry sub region   (K) | `convection__subreg_dry_t` | D | #692 |
| `5-605` | Temperature of liq sub region   (K) | `convection__subreg_liq_t` | D | #692 |
| `5-606` | Temp of mixed phase sub region   (K) | `convection__subreg_mph_t` | D | #692 |
| `5-607` | Temp of ice rain sub region      (K) | `convection__subreg_icr_t` | D | #692 |
| `5-608` | Water Vap of dry sub region  (kg/kg) | `convection__subreg_dry_q` | D | #692 |
| `5-609` | Water Vap of liq sub region  (kg/kg) | `convection__subreg_liq_q` | D | #692 |
| `5-610` | Water Vap of mix phase subreg (kg/kg) | `convection__subreg_mph_q` | D | #692 |
| `5-611` | Water Vap of ice rain sub reg (kg/kg) | `convection__subreg_icr_q` | D | #692 |
| `5-612` | Relative humidity of dry sub region | `convection__subreg_dry_rhl` | D | #692 |
| `5-613` | Relative humidity of liq sub region | `convection__subreg_liq_rhl` | D | #692 |
| `5-614` | Relative humidity of mix phase subreg | `convection__subreg_mph_rhl` | D | #692 |
| `5-615` | Relative humidity of ice rain sub reg | `convection__subreg_icr_rhl` | D | #692 |
| `5-616` | Downdraught mass flux rho levels Pa/s | `convection__massflux_down_half` | D | #692 |

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [ ] Comments have been included that aid understanding and enhance the readability of the code
- [ ] My changes generate no new warnings
- [ ] All automated checks in the CI pipeline have completed successfully

## Testing

- [ ] I have tested this change locally, using the LFRic Apps rose-stem suite
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

## Security Considerations

- [ ] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
