### PR TITLE
Right levels used regridding 265 Area cloud fraction with lfric2um

### DIFF
--- a/applications/lfricinputs/source/common/lfricinp_gather_lfric_field_mod.f90
+++ b/applications/lfricinputs/source/common/lfricinp_gather_lfric_field_mod.f90
@@ -28,7 +28,7 @@ public :: lfricinp_gather_lfric_field
 contains
 
 subroutine lfricinp_gather_lfric_field( lfric_field, global_field_array, comm, &
-                                        num_levels, level, twod_mesh )
+                                        level, twod_mesh )
 
 implicit none
 !
@@ -38,10 +38,9 @@ implicit none
 !  and puts into correct location using the global id (gid) map
 !
 ! Arguments
-type(field_type),    intent(INOUT) :: lfric_field
+type(field_type),    intent(in)    :: lfric_field
 real(kind=real64),   intent(out)   :: global_field_array(:)
 type(lfric_comm_type), intent(in)  :: comm
-integer(kind=int64), intent(in)    :: num_levels
 integer(kind=int64), intent(in)    :: level
 type(mesh_type),     intent(in), pointer :: twod_mesh
 
@@ -56,6 +55,7 @@ integer(kind=int32), parameter   :: rank_0 = 0
 integer(kind=int32) :: err, i
 integer(kind=int64) :: index_3d
 integer(kind=i_def) :: mpi_comm
+integer(kind=i_def) :: num_levels
 !, unit_num
 
 real(kind=real64), allocatable :: local_data(:)
@@ -69,9 +69,13 @@ mesh => lfric_field%get_mesh()
 
 field_proxy = lfric_field%get_proxy()
 
-! Get number of layers from function space, as we have W3, Wtheta and W3 2d
-! fields which have different number of layers
-!nlayers = fs%get_nlayers()
+! Get number of layers by dividing the number of dofs in the local domain
+! by the number of 2D cells and number of dofs per dof-location. Calculation
+! accounts for the fact that Wtheta fields have one extra level than W3 field
+! even though the number of levels in each function space is the same
+num_levels = field_proxy%vspace%get_last_dof_annexed() /                     &
+                (mesh%get_last_edge_cell() * field_proxy%vspace%get_ndata())
+
 local_rank = global_mpi%get_comm_rank()
 total_ranks = global_mpi%get_comm_size()
 

--- a/applications/lfricinputs/source/lfric2um/lfric2um_main_loop_mod.f90
+++ b/applications/lfricinputs/source/lfric2um/lfric2um_main_loop_mod.f90
@@ -30,12 +30,14 @@ use lfricinp_stashmaster_mod,          only: get_stashmaster_item, levelt,     &
                                              stashcode_q, stashcode_theta,     &
                                              theta_levels
 use lfricinp_um_grid_mod,              only: um_grid
-use lfricinp_um_level_codes_mod,       only: lfricinp_get_num_levels
+use lfricinp_um_level_codes_mod,       only: lfricinp_get_num_levels,          &
+                                             lfricinp_get_first_level_num
 
 ! lfric modules
 use field_mod,  only: field_type
 use log_mod,    only: log_event, log_scratch_space,   &
-                      LOG_LEVEL_INFO, LOG_LEVEL_ERROR
+                      LOG_LEVEL_INFO, LOG_LEVEL_ERROR,&
+                      log_level_warning
 
 implicit none
 
@@ -53,7 +55,13 @@ subroutine lfric2um_main_loop()
 implicit none
 
 integer(kind=int64) :: i_stash, level, i_field
-integer(kind=int64) :: stashcode, num_levels
+integer(kind=int64) :: stashcode
+! Number of levels in UM field
+integer(kind=int64) :: n_um_levels
+integer(kind=int64) :: um_first_level
+integer(kind=int64) :: um_level_type
+! Set to identify fields where first LFRic level is ignored
+integer(kind=int64) :: lfric_level_offset
 character(len=*), parameter :: routinename='lfric2um_main_loop'
 type(field_type), pointer :: lfric_field
 type(lfricinp_regrid_weights_type), pointer :: weights
@@ -76,7 +84,17 @@ do i_stash = 1, lfric2um_config%num_fields
   stashcode = lfric2um_config%stash_list(i_stash)
   write(log_scratch_space, '(A,I0)') "Processing stashcode ", stashcode
   call log_event(log_scratch_space, LOG_LEVEL_INFO)
-  num_levels = lfricinp_get_num_levels(um_output_file, stashcode)
+  n_um_levels = lfricinp_get_num_levels(um_output_file, stashcode)
+  um_first_level = lfricinp_get_first_level_num(stashcode)
+  um_level_type = get_stashmaster_item(stashcode, levelt)
+  lfric_level_offset = 0
+  if (um_level_type == 2 .and. um_first_level == 1) then
+    ! UM data will be on theta levels, but without a value at the first level
+    ! Therefore, first LFRic layer needs to be ignored
+    lfric_level_offset = 1
+    write(log_scratch_space,'(A)')'First LFRic level ignored for this stashcode'
+    call log_event(log_scratch_space, log_level_info)
+  end if
 
   !---------------------------------------------------------------------------
   ! Select appropriate weights
@@ -104,14 +122,14 @@ do i_stash = 1, lfric2um_config%num_fields
   !---------------------------------------------------------------------------
   ! Loop over number of levels in field
   !---------------------------------------------------------------------------
-  do level = 1, num_levels
+  do level = 1, n_um_levels - lfric_level_offset
     global_field_array(:) = 0.0_real64
 
     !---------------------------------------------------------------------------
     ! Gather local lfric fields into global array on base rank
     !---------------------------------------------------------------------------
     call lfricinp_gather_lfric_field( lfric_field, global_field_array, comm, &
-         level, twod_mesh )
+         level + lfric_level_offset, twod_mesh )
     if (local_rank == 0 ) then
 
       !-------------------------------------------------------------------------
@@ -138,14 +156,14 @@ do i_stash = 1, lfric2um_config%num_fields
       ! Copy the pointers for the top-level fields needed to compute the
       ! Exner pressure at the half level immediately above the model top
       !-------------------------------------------------------------------------
-      if (stashcode == stashcode_q .and. level == num_levels) then
+      if (stashcode == stashcode_q .and. level == n_um_levels) then
         q_top_buffer(:,:) = um_output_file%fields(i_field)%rdata(:,:)
-      else if (stashcode == stashcode_theta .and. level == num_levels) then
+      else if (stashcode == stashcode_theta .and. level == n_um_levels) then
         theta_top_buffer(:,:) = um_output_file%fields(i_field)%rdata(:,:)
-      else if (stashcode == stashcode_exner .and. level == num_levels) then
+      else if (stashcode == stashcode_exner .and. level == n_um_levels) then
         exner_top_buffer(:,:) = um_output_file%fields(i_field)%rdata(:,:)
         l_conv_p_exner = .false.
-      else if (stashcode == stashcode_p .and. level == num_levels) then
+      else if (stashcode == stashcode_p .and. level == n_um_levels) then
         exner_top_buffer(:,:) = um_output_file%fields(i_field)%rdata(:,:)
         l_conv_p_exner = .true.
       end if
@@ -168,7 +186,7 @@ do i_stash = 1, lfric2um_config%num_fields
   ! Add the additional upper level for the Exner pressure
   !---------------------------------------------------------------------------
   if (stashcode == stashcode_exner .or. stashcode == stashcode_p) then
-    level = num_levels + 1
+    level = n_um_levels + 1
     if (local_rank == 0) then
       call lfricinp_add_um_field_to_file(um_output_file, stashcode, &
            level, um_grid, lfric2um_config%lbtim_list(i_stash),     &

--- a/applications/lfricinputs/source/lfric2um/lfric2um_main_loop_mod.f90
+++ b/applications/lfricinputs/source/lfric2um/lfric2um_main_loop_mod.f90
@@ -122,7 +122,7 @@ do i_stash = 1, lfric2um_config%num_fields
   !---------------------------------------------------------------------------
   ! Loop over number of levels in field
   !---------------------------------------------------------------------------
-  do level = 1, n_um_levels - lfric_level_offset
+  do level = 1, n_um_levels
     global_field_array(:) = 0.0_real64
 
     !---------------------------------------------------------------------------

--- a/applications/lfricinputs/source/lfric2um/lfric2um_main_loop_mod.f90
+++ b/applications/lfricinputs/source/lfric2um/lfric2um_main_loop_mod.f90
@@ -111,7 +111,7 @@ do i_stash = 1, lfric2um_config%num_fields
     ! Gather local lfric fields into global array on base rank
     !---------------------------------------------------------------------------
     call lfricinp_gather_lfric_field( lfric_field, global_field_array, comm, &
-         num_levels, level, twod_mesh )
+         level, twod_mesh )
     if (local_rank == 0 ) then
 
       !-------------------------------------------------------------------------


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: <!-- SR id, filled by author when ready for review (e.g. @octocat) -->
Code Reviewer: @mo-alistairp 

Closes #694 where the technical issue is described in depth.
 
This branch ensures the correct number of layers is used for gathering LFRic data. Previously, it was assumed to be the same as the UM number of layers, which is incorrect for STASH code 265 (area cloud fraction), as can be seen by noting the corruption of the data as compared with the very similar 266 STASH code.

Where an LFRic field has more layers than the UM field, one must decide what to do. In the above case, ignoring level 1 of the LFRic field looks correct as the first two levels of the field (the two Wtheta dofs in the lowest cell) are identical. This was further checked by reviewing the input data to the um2lfric aquaplanet task that generated the input data for the lfric2um aquaplanet task: the first two levels in the field in this file are *not* identical and look more like the regridded data of levels 2 and 3 of the LFRic field, respectively.

Finally, um2lfric code was examined. um2lfric creates an LFRic-like array used for regridding UM data into which. It then calls a post_process routine which, for LFRic field `area_cf` (which matches STASH code 265), it adds an extra level to the start of the array which is a duplicate of the first level.

The KGOs for the lfric2um aquaplanet tests are changed by this branch as expected. Just the area cloud fraction is affected, as expected. The cloud fraction plots are now similar to the bulk cloud fraction plots, and the change avoids the use of the duplicated level 0 layer of the LFRic data.

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #694 
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] I have tested this change locally, using the LFRic Apps rose-stem suite
- [x] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

Several non-lfricinputs builds ran out of time due to ongoing file-system issues. As the changes are fully isolated to lfricinputs it doesn't seem worth rerunning right now.

Three lfricinputs rose-ana tasks fail, all expected and relate to the corrected STASHcode 265. There are no other differences.

# Test Suite Results - lfric_apps - pr697_lfric2um_right_levels/run1

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [pr697_lfric2um_right_levels/run1](https://cylchub/services/cylc-review/cycles/steve.mullerworth/?suite=pr697_lfric2um_right_levels%2Frun1) |
| Suite User | steve.mullerworth |
| Workflow Start | 2026-08-06T17:02:04 |
| Groups Run | developer |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| casim | [MetOffice/casim@2026.07.1](https://github.com/MetOffice/casim/tree/2026.07.1) | True |
| jules | [MetOffice/jules@2026.07.1](https://github.com/MetOffice/jules/tree/2026.07.1) | True |
| lfric_apps | [stevemullerworth/lfric_apps@right_levels](https://github.com/stevemullerworth/lfric_apps/tree/right_levels) | False |
| lfric_core | [MetOffice/lfric_core@60fc29a](https://github.com/MetOffice/lfric_core/tree/60fc29a) | True |
| moci | [MetOffice/moci@2026.07.1](https://github.com/MetOffice/moci/tree/2026.07.1) | True |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@77a5166](https://github.com/MetOffice/SimSys_Scripts/tree/77a5166) | True |
| socrates | [MetOffice/socrates@2026.07.1](https://github.com/MetOffice/socrates/tree/2026.07.1) | True |
| socrates-spectral | [MetOffice/socrates-spectral@2026.07.1](https://github.com/MetOffice/socrates-spectral/tree/2026.07.1) | True |
| ukca | [MetOffice/ukca@9fc2b6d](https://github.com/MetOffice/ukca/tree/9fc2b6d) | True |

## Task Information
<details>
<summary>:x: failed tasks - 17</summary>

| Task | State |
| :--- | :--- |
| build_jedi_lfric_tests_azspice_gnu_fast-debug-64bit-rsolver64 | failed |
| build_jedi_lfric_tests_azspice_gnu_full-debug-64bit | failed |
| build_jules_azspice_gnu_fast-debug-64bit | failed |
| build_lfric2lfric_azspice_gnu_fast-debug-64bit | failed |
| build_lfric_atm_azspice_gnu_fast-debug-32bit | failed |
| build_lfric_atm_azspice_gnu_fast-debug-64bit | failed |
| build_lfric_atm_azspice_gnu_full-debug-32bit | failed |
| build_name_transport_azspice_gnu_fast-debug-64bit | failed |
| build_name_transport_unit_tests_azspice_gnu_64bit | failed |
| build_physics_schemes_interface_unit_tests_azspice_gnu_64bit | failed |
| build_science_shared_unit_tests_azspice_gnu_64bit | failed |
| build_shallow_water_azspice_gnu_fast-debug-64bit | failed |
| build_shallow_water_unit_tests_azspice_gnu_64bit | failed |
| build_solver_azspice_gnu_fast-debug-64bit | failed |
| rose_ana_lfricinputs_lfric2um-aquaplanet-C48L38_N48L38_azspice_gnu_fast-debug-64bit | failed |
| rose_ana_lfricinputs_lfric2um-aquaplanet-C48L38_N48L38_azspice_gnu_full-debug-64bit | failed |
| rose_ana_lfricinputs_lfric2um-aquaplanet-C48L38_N48L38_ex1a_gnu_fast-debug-64bit | failed |
</details>
:white_check_mark: succeeded tasks - 1005
<details>
<summary>:hourglass: waiting tasks - 68</summary>

| Task | State |
| :--- | :--- |
| run_jedi_lfric_tests_forecast_nwp_gal9-C12_azspice_gnu_full-debug-64bit | waiting |
| run_jedi_lfric_tests_forecast_nwp_gal9-C48_MG_azspice_gnu_full-debug-64bit | waiting |
| run_jedi_lfric_tests_forecast_nwp_gal9_da-C12_azspice_gnu_full-debug-64bit | waiting |
| run_jedi_lfric_tests_forecast_pseudo_pseudomodel-C12_azspice_gnu_full-debug-64bit | waiting |
| run_jedi_lfric_tests_runge-kutta-C12_azspice_gnu_full-debug-64bit | waiting |
| run_jedi_lfric_tests_tlm_tests_nwp_gal9-strict_solver-4OMP-C12_MG_azspice_gnu_fast-debug-64bit-rsolver64 | waiting |
| run_jules_dice2-BiP2x2-50000x50000_azspice_gnu_fast-debug-64bit | waiting |
| run_lfric2lfric_clim_gal9-C24_C12_1cpu_azspice_gnu_fast-debug-64bit | waiting |
| run_lfric2lfric_oasis_clim_gal9-C24_C12_1cpu_azspice_gnu_fast-debug-64bit | waiting |
| run_lfric2lfric_oasis_clim_gal9_C12-ral_seuk_C16_lam-lbc_1cpu_azspice_gnu_fast-debug-64bit | waiting |
| run_lfric2lfric_oasis_clim_gal9_C12-ral_seuk_C16_lam_1cpu_azspice_gnu_fast-debug-64bit | waiting |
| run_lfric2lfric_oasis_ral_seuk-C32_lam_MG_1cpu_azspice_gnu_fast-debug-64bit | waiting |
| run_lfric2lfric_ral3-seuk_azspice_gnu_fast-debug-64bit | waiting |
| run_lfric2lfric_ral_seuk-C32_lam_MG_1cpu_azspice_gnu_fast-debug-64bit | waiting |
| run_lfric_atm_clim_gal9-C12_azspice_gnu_fast-debug-32bit-crun0 | waiting |
| run_lfric_atm_clim_gal9_short-C12_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_clim_gal9_short-C12_azspice_gnu_fast-debug-32bit-crun0 | waiting |
| run_lfric_atm_nwp_gal9-C12_azspice_gnu_fast-debug-32bit-crun0 | waiting |
| run_lfric_atm_nwp_gal9-C12_azspice_gnu_fast-debug-64bit-crun0 | waiting |
| run_lfric_atm_nwp_gal9_debug-C12_azspice_gnu_full-debug-32bit | waiting |
| run_lfric_atm_nwp_gal9_short-C12_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_nwp_gal9_short-C12_azspice_gnu_fast-debug-32bit-crun0 | waiting |
| run_lfric_atm_ral3-seuk_MG_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_ral3-seuk_MG_azspice_gnu_fast-debug-32bit-crun0 | waiting |
| run_lfric_atm_ral3_ens-seuk_MG_azspice_gnu_fast-debug-32bit-crun0 | waiting |
| run_lfric_atm_ral3_mixmol-seuk_MG_azspice_gnu_fast-debug-32bit-crun0 | waiting |
| run_lfric_atm_rce-BiP64x64-1500x1500_MG_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_coma9_bomex-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_coma9_toga-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_comorph_dev_bomex-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_comorph_dev_toga-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_gal9_bomex-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_gal9_cbl_dry-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_gal9_comp_tran_ref-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_gal9_dice2-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_gal9_gabls4-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_gal9_sahara-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_gal9_seaice-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_gal9_snow-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_gal9_toga-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_hd209458b-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_llcs-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_rad_gas-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_ral3_constrain-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_ral3_moruses-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_ral3_urban2t-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_ukca_land-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_ukca_land-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit-crun0 | waiting |
| run_lfric_atm_scm_ukca_sea-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit | waiting |
| run_lfric_atm_scm_ukca_sea-BiP2x2-50000x50000_azspice_gnu_fast-debug-32bit-crun0 | waiting |
| run_name_transport_cylinder_xz-BiP100x10-20x20_azspice_gnu_fast-debug-64bit | waiting |
| run_name_transport_hadley_dcmip-C24_azspice_gnu_fast-debug-64bit | waiting |
| run_name_transport_sbr_hori_lam-n96_lam_azspice_gnu_fast-debug-64bit | waiting |
| run_shallow_water_galewsky-C24_azspice_gnu_fast-debug-64bit | waiting |
| run_shallow_water_galewsky_vi-C24_azspice_gnu_fast-debug-64bit | waiting |
| run_shallow_water_gaussian-BiP32x32-1x1_azspice_gnu_fast-debug-64bit-crun0 | waiting |
| run_shallow_water_gaussian_ex-BiP32x32-1x1_azspice_gnu_fast-debug-64bit | waiting |
| run_shallow_water_gaussian_vi-BiP32x32-1x1_azspice_gnu_fast-debug-64bit | waiting |
| run_shallow_water_thermal_vi-BiP32x32-1x1_azspice_gnu_fast-debug-64bit | waiting |
| run_shallow_water_williamson2_vi-C24_azspice_gnu_fast-debug-64bit | waiting |
| run_shallow_water_williamson5_vi-C24_azspice_gnu_fast-debug-64bit | waiting |
| run_solver_bicgstab-C24_azspice_gnu_fast-debug-64bit | waiting |
| run_solver_cg-C24_azspice_gnu_fast-debug-64bit | waiting |
| run_solver_fgmres-C24_azspice_gnu_fast-debug-64bit | waiting |
| run_solver_gcr-C24_azspice_gnu_fast-debug-64bit | waiting |
| run_solver_gmres-C24_azspice_gnu_fast-debug-64bit | waiting |
| run_solver_jacobi-C24_azspice_gnu_fast-debug-64bit | waiting |
| run_solver_prec_only-C24_azspice_gnu_fast-debug-64bit | waiting |
</details>



## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [x] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
