### PR TITLE
Add UKCA GLOMAP dust mass and CN/CCN number concentration diags

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -55,3 +55,4 @@
 | marcstring          | Marc Stringer      | NCAS, Reading University         | 2026-05-06 |
 | cameronbateman-mo   | Cameron Bateman    | Met Office                       | 2026-05-28 |
 | davelee2804         | David Lee          | Bureau of Meteorology, Australia | 2026-06-02 |
+| zmaalick            | Zubair Maalick     | Met Office                       | 2026-08-28 |

--- a/applications/lfric_atm/metadata/field_def_diags.xml
+++ b/applications/lfric_atm/metadata/field_def_diags.xml
@@ -198,6 +198,18 @@
   <field id="aerosol__acc_ins_du" name="acc_ins_du" long_name="accumulation_insoluble_mode_dust_mmr" unit="kg kg-1" grid_ref="full_level_face_grid" />
   <field id="aerosol__n_cor_ins" name="n_cor_ins" long_name="coarse_insoluble_mode_number" unit="1" grid_ref="full_level_face_grid" />
   <field id="aerosol__cor_ins_du" name="cor_ins_du" long_name="coarse_insoluble_mode_dust_mmr" unit="kg kg-1" grid_ref="full_level_face_grid" />
+  <!-- Dust mass concentrations (UM STASH m01s38i502, m01s38i503). GLOMAP-mode
+       component mass concentration is the component mass mixing ratio times
+       the air density (see ukca_mode_diags_mod mode_diags_cmip6). -->
+  <field id="aerosol__mconc_du_acc_ins" name="mconc_du_acc_ins" long_name="mass_concentration_of_dust_in_accumulation_insoluble_mode" unit="kg m-3" grid_ref="full_level_face_grid"> aerosol__acc_ins_du * rho_in_wth </field>
+  <field id="aerosol__mconc_du_cor_ins" name="mconc_du_cor_ins" long_name="mass_concentration_of_dust_in_coarse_insoluble_mode" unit="kg m-3" grid_ref="full_level_face_grid"> aerosol__cor_ins_du * rho_in_wth </field>
+  <!-- CN and CCN number concentrations (UM STASH m01s38i437, m01s38i700,
+       m01s38i701). Summed over the six GLOMAP modes that carry a dry modal
+       diameter in LFRic; the nucleation-soluble mode is excluded because no
+       drydp_nuc_sol field exists. -->
+  <field id="aerosol__cn_number_conc" name="cn_number_conc" long_name="condensation_nuclei_number_concentration_for_dry_diameter_greater_than_3nm_excluding_nucleation_mode" unit="cm-3" grid_ref="full_level_face_grid" />
+  <field id="aerosol__ccn_number_conc_30nm" name="ccn_number_conc_30nm" long_name="cloud_condensation_nuclei_number_concentration_for_dry_diameter_greater_than_30nm" unit="cm-3" grid_ref="full_level_face_grid" />
+  <field id="aerosol__ccn_number_conc_50nm" name="ccn_number_conc_50nm" long_name="cloud_condensation_nuclei_number_concentration_for_dry_diameter_greater_than_50nm" unit="cm-3" grid_ref="full_level_face_grid" />
   <field id="aerosol__cloud_drop_no_conc" name="cloud_drop_no_conc" long_name="cloud_droplet_number_concentration" unit="m-3" grid_ref="full_level_face_grid" />
   <field id="aerosol__drydp_ait_sol" name="drydp_ait_sol" long_name="dry_modal_diameter_of_aitken_soluble_mode" unit="m" grid_ref="full_level_face_grid" />
   <field id="aerosol__drydp_acc_sol" name="drydp_acc_sol" long_name="dry_modal_diameter_of_accumulation_soluble_mode" unit="m" grid_ref="full_level_face_grid" />

--- a/applications/lfric_atm/metadata/field_def_diags.xml
+++ b/applications/lfric_atm/metadata/field_def_diags.xml
@@ -170,6 +170,7 @@
   <field id="chemistry__tio" name="tio" long_name="mass_fraction_of_titanium_oxide_in_air" unit="kg kg-1" operation="once" grid_ref="full_level_face_grid" />
   <field id="chemistry__vo" name="vo" long_name="mass_fraction_of_vanadium_oxide_in_air" unit="kg kg-1" operation="once" grid_ref="full_level_face_grid" />  
   <field id="chemistry__photol_rate_jo1d" name="photol_rate_jo1d" long_name="photolysis_rate_of_ozone_to_1d_oxygen_atom" unit="s-1" grid_ref="full_level_face_grid" />
+  <field id="chemistry__photol_rate_jo3p" name="photol_rate_jo3p" long_name="photolysis_rate_of_ozone_to_triplet_oxygen_atom" unit="s-1" grid_ref="full_level_face_grid" />
   <field id="chemistry__photol_rate_jno2" name="photol_rate_jno2" long_name="photolysis_rate_of_nitrogen_dioxide" unit="s-1" grid_ref="full_level_face_grid" />
   <!-- aerosol diagnostics -->
   <field id="aerosol__murk" name="murk" long_name="simple_single_species_aerosol_murk" unit="microg kg-1" grid_ref="full_level_face_grid" />

--- a/applications/lfric_atm/metadata/field_def_diags.xml
+++ b/applications/lfric_atm/metadata/field_def_diags.xml
@@ -200,9 +200,10 @@
   <field id="aerosol__cor_ins_du" name="cor_ins_du" long_name="coarse_insoluble_mode_dust_mmr" unit="kg kg-1" grid_ref="full_level_face_grid" />
   <!-- Dust mass concentrations (UM STASH m01s38i502, m01s38i503). GLOMAP-mode
        component mass concentration is the component mass mixing ratio times
-       the air density (see ukca_mode_diags_mod mode_diags_cmip6). -->
-  <field id="aerosol__mconc_du_acc_ins" name="mconc_du_acc_ins" long_name="mass_concentration_of_dust_in_accumulation_insoluble_mode" unit="kg m-3" grid_ref="full_level_face_grid"> aerosol__acc_ins_du * rho_in_wth </field>
-  <field id="aerosol__mconc_du_cor_ins" name="mconc_du_cor_ins" long_name="mass_concentration_of_dust_in_coarse_insoluble_mode" unit="kg m-3" grid_ref="full_level_face_grid"> aerosol__cor_ins_du * rho_in_wth </field>
+       the air density p / (Rd * T) (see ukca_mode_diags_mod mode_diags_cmip6).
+       Computed in glomap_ccn_diag_kernel_mod on the aerosol mesh. -->
+  <field id="aerosol__mconc_du_acc_ins" name="mconc_du_acc_ins" long_name="mass_concentration_of_dust_in_accumulation_insoluble_mode" unit="kg m-3" grid_ref="full_level_face_grid" />
+  <field id="aerosol__mconc_du_cor_ins" name="mconc_du_cor_ins" long_name="mass_concentration_of_dust_in_coarse_insoluble_mode" unit="kg m-3" grid_ref="full_level_face_grid" />
   <!-- CN and CCN number concentrations (UM STASH m01s38i437, m01s38i700,
        m01s38i701). Summed over the six GLOMAP modes that carry a dry modal
        diameter in LFRic; the nucleation-soluble mode is excluded because no

--- a/applications/lfric_atm/metadata/field_def_diags.xml
+++ b/applications/lfric_atm/metadata/field_def_diags.xml
@@ -170,7 +170,6 @@
   <field id="chemistry__tio" name="tio" long_name="mass_fraction_of_titanium_oxide_in_air" unit="kg kg-1" operation="once" grid_ref="full_level_face_grid" />
   <field id="chemistry__vo" name="vo" long_name="mass_fraction_of_vanadium_oxide_in_air" unit="kg kg-1" operation="once" grid_ref="full_level_face_grid" />  
   <field id="chemistry__photol_rate_jo1d" name="photol_rate_jo1d" long_name="photolysis_rate_of_ozone_to_1d_oxygen_atom" unit="s-1" grid_ref="full_level_face_grid" />
-  <field id="chemistry__photol_rate_jo3p" name="photol_rate_jo3p" long_name="photolysis_rate_of_ozone_to_triplet_oxygen_atom" unit="s-1" grid_ref="full_level_face_grid" />
   <field id="chemistry__photol_rate_jno2" name="photol_rate_jno2" long_name="photolysis_rate_of_nitrogen_dioxide" unit="s-1" grid_ref="full_level_face_grid" />
   <!-- aerosol diagnostics -->
   <field id="aerosol__murk" name="murk" long_name="simple_single_species_aerosol_murk" unit="microg kg-1" grid_ref="full_level_face_grid" />

--- a/applications/lfric_atm/metadata/field_def_diags.xml
+++ b/applications/lfric_atm/metadata/field_def_diags.xml
@@ -198,16 +198,8 @@
   <field id="aerosol__acc_ins_du" name="acc_ins_du" long_name="accumulation_insoluble_mode_dust_mmr" unit="kg kg-1" grid_ref="full_level_face_grid" />
   <field id="aerosol__n_cor_ins" name="n_cor_ins" long_name="coarse_insoluble_mode_number" unit="1" grid_ref="full_level_face_grid" />
   <field id="aerosol__cor_ins_du" name="cor_ins_du" long_name="coarse_insoluble_mode_dust_mmr" unit="kg kg-1" grid_ref="full_level_face_grid" />
-  <!-- Dust mass concentrations (UM STASH m01s38i502, m01s38i503). GLOMAP-mode
-       component mass concentration is the component mass mixing ratio times
-       the air density p / (Rd * T) (see ukca_mode_diags_mod mode_diags_cmip6).
-       Computed in glomap_ccn_diag_kernel_mod on the aerosol mesh. -->
   <field id="aerosol__mconc_du_acc_ins" name="mconc_du_acc_ins" long_name="mass_concentration_of_dust_in_accumulation_insoluble_mode" unit="kg m-3" grid_ref="full_level_face_grid" />
   <field id="aerosol__mconc_du_cor_ins" name="mconc_du_cor_ins" long_name="mass_concentration_of_dust_in_coarse_insoluble_mode" unit="kg m-3" grid_ref="full_level_face_grid" />
-  <!-- CN and CCN number concentrations (UM STASH m01s38i437, m01s38i700,
-       m01s38i701). Summed over the six GLOMAP modes that carry a dry modal
-       diameter in LFRic; the nucleation-soluble mode is excluded because no
-       drydp_nuc_sol field exists. -->
   <field id="aerosol__cn_number_conc" name="cn_number_conc" long_name="condensation_nuclei_number_concentration_for_dry_diameter_greater_than_3nm_excluding_nucleation_mode" unit="cm-3" grid_ref="full_level_face_grid" />
   <field id="aerosol__ccn_number_conc_30nm" name="ccn_number_conc_30nm" long_name="cloud_condensation_nuclei_number_concentration_for_dry_diameter_greater_than_30nm" unit="cm-3" grid_ref="full_level_face_grid" />
   <field id="aerosol__ccn_number_conc_50nm" name="ccn_number_conc_50nm" long_name="cloud_condensation_nuclei_number_concentration_for_dry_diameter_greater_than_50nm" unit="cm-3" grid_ref="full_level_face_grid" />

--- a/interfaces/physics_schemes_interface/source/algorithm/aerosol_ukca_alg_mod.x90
+++ b/interfaces/physics_schemes_interface/source/algorithm/aerosol_ukca_alg_mod.x90
@@ -72,6 +72,7 @@ contains
                                              get_detj_at_w3_fv
     use physics_constants_mod,         only: get_rdz_w3
     use aerosol_ukca_kernel_mod,       only: aerosol_ukca_kernel_type
+    use glomap_ccn_diags_mod,          only: output_diags_for_glomap_ccn
     use io_config_mod,                 only: use_xios_io, write_diag
     use xios,                          only: xios_date, xios_get_current_date, &
                                              xios_date_get_day_of_year
@@ -1659,6 +1660,22 @@ contains
       call pvol_om_ait_ins%write_field('aerosol__pvol_om_ait_ins')
       call pvol_du_acc_ins%write_field('aerosol__pvol_du_acc_ins')
       call pvol_du_cor_ins%write_field('aerosol__pvol_du_cor_ins')
+
+      ! CN and CCN number concentrations, computed only when requested
+      call output_diags_for_glomap_ccn( state(igh_t),                          &
+                                        exner_in_wth,                          &
+                                        n_ait_sol,                             &
+                                        n_acc_sol,                             &
+                                        n_cor_sol,                             &
+                                        n_ait_ins,                             &
+                                        n_acc_ins,                             &
+                                        n_cor_ins,                             &
+                                        drydp_ait_sol,                         &
+                                        drydp_acc_sol,                         &
+                                        drydp_cor_sol,                         &
+                                        drydp_ait_ins,                         &
+                                        drydp_acc_ins,                         &
+                                        drydp_cor_ins )
 
       if ( LPROF ) call stop_timing( id_diags, 'diags.ukca' )
     end if      ! write diag

--- a/interfaces/physics_schemes_interface/source/algorithm/aerosol_ukca_alg_mod.x90
+++ b/interfaces/physics_schemes_interface/source/algorithm/aerosol_ukca_alg_mod.x90
@@ -74,6 +74,7 @@ contains
     use aerosol_ukca_kernel_mod,       only: aerosol_ukca_kernel_type
     use glomap_ccn_diags_mod,          only: output_diags_for_glomap_ccn
     use io_config_mod,                 only: use_xios_io, write_diag
+    use initialise_diagnostics_mod,    only: init_diag => init_diagnostic_field
     use xios,                          only: xios_date, xios_get_current_date, &
                                              xios_date_get_day_of_year
     use timing_mod,                    only: start_timing, stop_timing, &
@@ -424,8 +425,13 @@ contains
     ! Photolysis rates array and sample output fields
     type( field_type ) :: photol_rates
     type( field_type ) :: photol_rate_jo1d
+    type( field_type ) :: photol_rate_jo3p
     type( field_type ) :: photol_rate_jno2
     type( field_type ) :: photol_rate_profile
+
+    logical(l_def) :: photol_rate_jo1d_flag
+    logical(l_def) :: photol_rate_jo3p_flag
+    logical(l_def) :: photol_rate_jno2_flag
 
     ! Other Photolysis driving fields - pre-set currently
     type( field_type ) :: sulp_accum
@@ -1023,12 +1029,27 @@ contains
          photol_scheme /= photol_scheme_off ) then
       ! Photolysis currently linked to Strattrop      
 
-      ! Sample Rates to output; wtheta grid
-      call ls_rain_3d%copy_field_properties(photol_rate_jo1d)
-      call ls_rain_3d%copy_field_properties(photol_rate_jno2)
+      ! Sample Rates to output; wtheta grid. Only create and populate a field
+      ! if it has actually been requested for output.
+      photol_rate_jo1d_flag = init_diag( photol_rate_jo1d,                    &
+                                        'chemistry__photol_rate_jo1d' )
+      photol_rate_jo3p_flag = init_diag( photol_rate_jo3p,                    &
+                                        'chemistry__photol_rate_jo3p' )
+      photol_rate_jno2_flag = init_diag( photol_rate_jno2,                    &
+                                        'chemistry__photol_rate_jno2' )
 
-      call invoke( setval_c(photol_rate_jo1d,  0.0_r_def),                     &
-                   setval_c(photol_rate_jno2,  0.0_r_def) )
+      if ( photol_rate_jo1d_flag .or. photol_rate_jo3p_flag .or.               &
+           photol_rate_jno2_flag ) then
+        if ( photol_rate_jo1d_flag ) then
+          call invoke( setval_c(photol_rate_jo1d,  0.0_r_def) )
+        end if
+        if ( photol_rate_jo3p_flag ) then
+          call invoke( setval_c(photol_rate_jo3p,  0.0_r_def) )
+        end if
+        if ( photol_rate_jno2_flag ) then
+          call invoke( setval_c(photol_rate_jno2,  0.0_r_def) )
+        end if
+      end if
       
       ! Only call photolysis if this is a chemistry timestep as photol rates
       ! are only used by chemistry
@@ -1109,20 +1130,31 @@ contains
                                             cv_base,                           &
                                             cv_top ) )
 
-            ! Extract sample rates from full array for verification
-            ! Currently only rates for O1D and NO2 output, so ignore others
+            ! Extract sample rates from full array for verification.
+            ! Only requested diagnostics are populated.
             do jp1 = 1, n_phot_spc
               select case(trim(ratj_varnames(jp1)))
               case ('jo3a')
-                !  jO(1D)         
-                call invoke (  photol_diags_kernel_type(photol_rate_jo1d,      &
-                                                        jp1,                   &
-                                                        photol_rates) )
+                if ( photol_rate_jo1d_flag ) then
+                  !  jO(1D)
+                  call invoke (  photol_diags_kernel_type(photol_rate_jo1d,    &
+                                                          jp1,                   &
+                                                          photol_rates) )
+                end if
+              case ('jo3b', 'jo3p')
+                if ( photol_rate_jo3p_flag ) then
+                  !  jO(3P)
+                  call invoke (  photol_diags_kernel_type(photol_rate_jo3p,    &
+                                                          jp1,                   &
+                                                          photol_rates) )
+                end if
               case ('jno2')
-                !  jNO2
-                call invoke (  photol_diags_kernel_type(photol_rate_jno2,      &
-                                                        jp1,                   &
-                                                        photol_rates) )
+                if ( photol_rate_jno2_flag ) then
+                  !  jNO2
+                  call invoke (  photol_diags_kernel_type(photol_rate_jno2,    &
+                                                          jp1,                   &
+                                                          photol_rates) )
+                end if
               end select
             end do
   
@@ -1570,8 +1602,15 @@ contains
         call emiss_no_aircrft%write_field('chemistry__emiss_no_aircrft')
 
         if (photol_scheme /= photol_scheme_off )  then
-          call photol_rate_jo1d%write_field('chemistry__photol_rate_jo1d')
-          call photol_rate_jno2%write_field('chemistry__photol_rate_jno2')
+          if ( photol_rate_jo1d_flag ) then
+            call photol_rate_jo1d%write_field('chemistry__photol_rate_jo1d')
+          end if
+          if ( photol_rate_jo3p_flag ) then
+            call photol_rate_jo3p%write_field('chemistry__photol_rate_jo3p')
+          end if
+          if ( photol_rate_jno2_flag ) then
+            call photol_rate_jno2%write_field('chemistry__photol_rate_jno2')
+          end if
         end if  
       end if    ! chem_scheme_strattrop
 

--- a/interfaces/physics_schemes_interface/source/algorithm/aerosol_ukca_alg_mod.x90
+++ b/interfaces/physics_schemes_interface/source/algorithm/aerosol_ukca_alg_mod.x90
@@ -1661,7 +1661,8 @@ contains
       call pvol_du_acc_ins%write_field('aerosol__pvol_du_acc_ins')
       call pvol_du_cor_ins%write_field('aerosol__pvol_du_cor_ins')
 
-      ! CN and CCN number concentrations, computed only when requested
+      ! CN and CCN number concentrations and dust mass concentrations,
+      ! computed only when requested
       call output_diags_for_glomap_ccn( state(igh_t),                          &
                                         exner_in_wth,                          &
                                         n_ait_sol,                             &
@@ -1675,7 +1676,9 @@ contains
                                         drydp_cor_sol,                         &
                                         drydp_ait_ins,                         &
                                         drydp_acc_ins,                         &
-                                        drydp_cor_ins )
+                                        drydp_cor_ins,                         &
+                                        acc_ins_du,                            &
+                                        cor_ins_du )
 
       if ( LPROF ) call stop_timing( id_diags, 'diags.ukca' )
     end if      ! write diag

--- a/interfaces/physics_schemes_interface/source/algorithm/aerosol_ukca_alg_mod.x90
+++ b/interfaces/physics_schemes_interface/source/algorithm/aerosol_ukca_alg_mod.x90
@@ -74,7 +74,6 @@ contains
     use aerosol_ukca_kernel_mod,       only: aerosol_ukca_kernel_type
     use glomap_ccn_diags_mod,          only: output_diags_for_glomap_ccn
     use io_config_mod,                 only: use_xios_io, write_diag
-    use initialise_diagnostics_mod,    only: init_diag => init_diagnostic_field
     use xios,                          only: xios_date, xios_get_current_date, &
                                              xios_date_get_day_of_year
     use timing_mod,                    only: start_timing, stop_timing, &
@@ -425,13 +424,8 @@ contains
     ! Photolysis rates array and sample output fields
     type( field_type ) :: photol_rates
     type( field_type ) :: photol_rate_jo1d
-    type( field_type ) :: photol_rate_jo3p
     type( field_type ) :: photol_rate_jno2
     type( field_type ) :: photol_rate_profile
-
-    logical(l_def) :: photol_rate_jo1d_flag
-    logical(l_def) :: photol_rate_jo3p_flag
-    logical(l_def) :: photol_rate_jno2_flag
 
     ! Other Photolysis driving fields - pre-set currently
     type( field_type ) :: sulp_accum
@@ -1029,27 +1023,12 @@ contains
          photol_scheme /= photol_scheme_off ) then
       ! Photolysis currently linked to Strattrop      
 
-      ! Sample Rates to output; wtheta grid. Only create and populate a field
-      ! if it has actually been requested for output.
-      photol_rate_jo1d_flag = init_diag( photol_rate_jo1d,                    &
-                                        'chemistry__photol_rate_jo1d' )
-      photol_rate_jo3p_flag = init_diag( photol_rate_jo3p,                    &
-                                        'chemistry__photol_rate_jo3p' )
-      photol_rate_jno2_flag = init_diag( photol_rate_jno2,                    &
-                                        'chemistry__photol_rate_jno2' )
+      ! Sample Rates to output; wtheta grid
+      call ls_rain_3d%copy_field_properties(photol_rate_jo1d)
+      call ls_rain_3d%copy_field_properties(photol_rate_jno2)
 
-      if ( photol_rate_jo1d_flag .or. photol_rate_jo3p_flag .or.               &
-           photol_rate_jno2_flag ) then
-        if ( photol_rate_jo1d_flag ) then
-          call invoke( setval_c(photol_rate_jo1d,  0.0_r_def) )
-        end if
-        if ( photol_rate_jo3p_flag ) then
-          call invoke( setval_c(photol_rate_jo3p,  0.0_r_def) )
-        end if
-        if ( photol_rate_jno2_flag ) then
-          call invoke( setval_c(photol_rate_jno2,  0.0_r_def) )
-        end if
-      end if
+      call invoke( setval_c(photol_rate_jo1d,  0.0_r_def),                     &
+                   setval_c(photol_rate_jno2,  0.0_r_def) )
       
       ! Only call photolysis if this is a chemistry timestep as photol rates
       ! are only used by chemistry
@@ -1130,31 +1109,20 @@ contains
                                             cv_base,                           &
                                             cv_top ) )
 
-            ! Extract sample rates from full array for verification.
-            ! Only requested diagnostics are populated.
+            ! Extract sample rates from full array for verification
+            ! Currently only rates for O1D and NO2 output, so ignore others
             do jp1 = 1, n_phot_spc
               select case(trim(ratj_varnames(jp1)))
               case ('jo3a')
-                if ( photol_rate_jo1d_flag ) then
-                  !  jO(1D)
-                  call invoke (  photol_diags_kernel_type(photol_rate_jo1d,    &
-                                                          jp1,                   &
-                                                          photol_rates) )
-                end if
-              case ('jo3b', 'jo3p')
-                if ( photol_rate_jo3p_flag ) then
-                  !  jO(3P)
-                  call invoke (  photol_diags_kernel_type(photol_rate_jo3p,    &
-                                                          jp1,                   &
-                                                          photol_rates) )
-                end if
+                !  jO(1D)         
+                call invoke (  photol_diags_kernel_type(photol_rate_jo1d,      &
+                                                        jp1,                   &
+                                                        photol_rates) )
               case ('jno2')
-                if ( photol_rate_jno2_flag ) then
-                  !  jNO2
-                  call invoke (  photol_diags_kernel_type(photol_rate_jno2,    &
-                                                          jp1,                   &
-                                                          photol_rates) )
-                end if
+                !  jNO2
+                call invoke (  photol_diags_kernel_type(photol_rate_jno2,      &
+                                                        jp1,                   &
+                                                        photol_rates) )
               end select
             end do
   
@@ -1602,15 +1570,8 @@ contains
         call emiss_no_aircrft%write_field('chemistry__emiss_no_aircrft')
 
         if (photol_scheme /= photol_scheme_off )  then
-          if ( photol_rate_jo1d_flag ) then
-            call photol_rate_jo1d%write_field('chemistry__photol_rate_jo1d')
-          end if
-          if ( photol_rate_jo3p_flag ) then
-            call photol_rate_jo3p%write_field('chemistry__photol_rate_jo3p')
-          end if
-          if ( photol_rate_jno2_flag ) then
-            call photol_rate_jno2%write_field('chemistry__photol_rate_jno2')
-          end if
+          call photol_rate_jo1d%write_field('chemistry__photol_rate_jo1d')
+          call photol_rate_jno2%write_field('chemistry__photol_rate_jno2')
         end if  
       end if    ! chem_scheme_strattrop
 

--- a/interfaces/physics_schemes_interface/source/algorithm/aerosol_ukca_alg_mod.x90
+++ b/interfaces/physics_schemes_interface/source/algorithm/aerosol_ukca_alg_mod.x90
@@ -444,6 +444,7 @@ contains
     type( field_type ), pointer :: w_in_wth     ! Vertical component of winds
     type( field_type ), pointer :: wetrho_in_w3 ! Wet density in W3
     type( field_type ), pointer :: wetrho_in_wth ! Wet density in WTHETA
+    type( field_type ), pointer :: rho_in_wth    ! Dry density in WTHETA
 
 
     ! Time variables
@@ -723,6 +724,7 @@ contains
     call derived_fields%get_field('w_in_wth', w_in_wth)
     call derived_fields%get_field('wetrho_in_w3', wetrho_in_w3)
     call derived_fields%get_field('wetrho_in_wth', wetrho_in_wth)
+    call derived_fields%get_field('rho_in_wth', rho_in_wth)
 
     ! Unpack other fields
     call radiation_fields%get_field('sin_stellar_declination_rts',             &
@@ -1665,6 +1667,7 @@ contains
       ! computed only when requested
       call output_diags_for_glomap_ccn( state(igh_t),                          &
                                         exner_in_wth,                          &
+                                        rho_in_wth,                            &
                                         n_ait_sol,                             &
                                         n_acc_sol,                             &
                                         n_cor_sol,                             &

--- a/interfaces/physics_schemes_interface/source/algorithm/glomap_aerosol_alg_mod.x90
+++ b/interfaces/physics_schemes_interface/source/algorithm/glomap_aerosol_alg_mod.x90
@@ -28,6 +28,7 @@ module glomap_aerosol_alg_mod
   use mesh_mod,                        only: mesh_type
   use fs_continuity_mod,               only: Wtheta
   use intermesh_mappings_alg_mod,      only: map_scalar_intermesh
+  use glomap_ccn_diags_mod,            only: output_diags_for_glomap_ccn
 
   implicit none
 
@@ -369,6 +370,22 @@ contains
       else
         call cloud_drop_no_conc_aero%write_field('aerosol__cloud_drop_no_conc')
       end if
+
+      ! CN and CCN number concentrations, computed only when requested
+      call output_diags_for_glomap_ccn( theta_in_wth,                          &
+                                        exner_in_wth,                          &
+                                        n_ait_sol,                             &
+                                        n_acc_sol,                             &
+                                        n_cor_sol,                             &
+                                        n_ait_ins,                             &
+                                        n_acc_ins,                             &
+                                        n_cor_ins,                             &
+                                        drydp_ait_sol,                         &
+                                        drydp_acc_sol,                         &
+                                        drydp_cor_sol,                         &
+                                        drydp_ait_ins,                         &
+                                        drydp_acc_ins,                         &
+                                        drydp_cor_ins )
 
       if ( LPROF ) call stop_timing( id_diags, 'diags.glomap_clim' )
     end if

--- a/interfaces/physics_schemes_interface/source/algorithm/glomap_aerosol_alg_mod.x90
+++ b/interfaces/physics_schemes_interface/source/algorithm/glomap_aerosol_alg_mod.x90
@@ -371,7 +371,8 @@ contains
         call cloud_drop_no_conc_aero%write_field('aerosol__cloud_drop_no_conc')
       end if
 
-      ! CN and CCN number concentrations, computed only when requested
+      ! CN and CCN number concentrations and dust mass concentrations,
+      ! computed only when requested
       call output_diags_for_glomap_ccn( theta_in_wth,                          &
                                         exner_in_wth,                          &
                                         n_ait_sol,                             &
@@ -385,7 +386,9 @@ contains
                                         drydp_cor_sol,                         &
                                         drydp_ait_ins,                         &
                                         drydp_acc_ins,                         &
-                                        drydp_cor_ins )
+                                        drydp_cor_ins,                         &
+                                        acc_ins_du,                            &
+                                        cor_ins_du )
 
       if ( LPROF ) call stop_timing( id_diags, 'diags.glomap_clim' )
     end if

--- a/interfaces/physics_schemes_interface/source/algorithm/glomap_aerosol_alg_mod.x90
+++ b/interfaces/physics_schemes_interface/source/algorithm/glomap_aerosol_alg_mod.x90
@@ -45,6 +45,7 @@ contains
   !>@param[in]     cloud_fields          humidity related fields
   !>@param[in]     theta_in_wth          Potential temperature (theta) wth space
   !>@param[in]     exner_in_wth          Exner Pressure in theta space
+  !>@param[in]     rho_in_wth            Dry density in theta space
   !>@param[in]     mr                    Mixing ratios at time level n
   !>@param[in]     timestep              Current timestep number
 
@@ -52,6 +53,7 @@ contains
                                  cloud_fields,                                 &
                                  theta_in_wth,                                 &
                                  exner_in_wth,                                 &
+                                 rho_in_wth,                                   &
                                  mr_n,                                         &
                                  timestep )
 
@@ -64,6 +66,7 @@ contains
     type( field_collection_type ), intent( in    ) :: cloud_fields
     type( field_type ), intent( in ) :: theta_in_wth
     type( field_type ), intent( in ) :: exner_in_wth
+    type( field_type ), intent( in ) :: rho_in_wth
     type( field_type ), intent( in ) :: mr_n(nummr)
     integer( kind=i_def ), intent( in ) :: timestep
 
@@ -375,6 +378,7 @@ contains
       ! computed only when requested
       call output_diags_for_glomap_ccn( theta_in_wth,                          &
                                         exner_in_wth,                          &
+                                        rho_in_wth,                            &
                                         n_ait_sol,                             &
                                         n_acc_sol,                             &
                                         n_cor_sol,                             &

--- a/interfaces/physics_schemes_interface/source/diagnostics/glomap_ccn_diags_mod.x90
+++ b/interfaces/physics_schemes_interface/source/diagnostics/glomap_ccn_diags_mod.x90
@@ -1,0 +1,170 @@
+!-----------------------------------------------------------------------------
+! (C) Crown copyright Met Office. All rights reserved.
+! The file LICENCE, distributed with this code, contains details of the terms
+! under which the code may be used.
+!-----------------------------------------------------------------------------
+
+!> @brief Processes the GLOMAP-mode condensation and cloud condensation
+!>        nuclei number concentration diagnostics.
+!> @details The three diagnostics are derived from the aerosol size
+!>          distribution rather than being scheme outputs, so they are
+!>          computed at output time and only when at least one of them has
+!>          been requested. The same routine serves both the GLOMAP
+!>          climatology and the prognostic UKCA paths.
+
+module glomap_ccn_diags_mod
+
+  use constants_mod,              only: l_def
+  use field_mod,                  only: field_type
+  use mesh_mod,                   only: mesh_type
+  use initialise_diagnostics_mod, only: init_diag => init_diagnostic_field
+
+  implicit none
+
+  private
+
+  public :: output_diags_for_glomap_ccn
+
+contains
+
+  !> @brief Compute and output the CN and CCN number concentrations
+  !> @details Reproduces the UM diagnostics m01s38i437, m01s38i700 and
+  !>          m01s38i701. The dry modal diameters are only refreshed on
+  !>          RADAER timesteps on the GLOMAP climatology path, so requesting
+  !>          these diagnostics more frequently than the RADAER call reuses
+  !>          the diameters of the most recent RADAER timestep.
+  !> @param[in] theta_in_wth  Potential temperature field
+  !> @param[in] exner_in_wth  Exner pressure in potential temperature space
+  !> @param[in] n_ait_sol     Aitken soluble mode number mixing ratio
+  !> @param[in] n_acc_sol     Accumulation soluble mode number mixing ratio
+  !> @param[in] n_cor_sol     Coarse soluble mode number mixing ratio
+  !> @param[in] n_ait_ins     Aitken insoluble mode number mixing ratio
+  !> @param[in] n_acc_ins     Accumulation insoluble mode number mixing ratio
+  !> @param[in] n_cor_ins     Coarse insoluble mode number mixing ratio
+  !> @param[in] drydp_ait_sol Aitken soluble mode dry modal diameter
+  !> @param[in] drydp_acc_sol Accumulation soluble mode dry modal diameter
+  !> @param[in] drydp_cor_sol Coarse soluble mode dry modal diameter
+  !> @param[in] drydp_ait_ins Aitken insoluble mode dry modal diameter
+  !> @param[in] drydp_acc_ins Accumulation insoluble mode dry modal diameter
+  !> @param[in] drydp_cor_ins Coarse insoluble mode dry modal diameter
+  subroutine output_diags_for_glomap_ccn( theta_in_wth,                        &
+                                          exner_in_wth,                        &
+                                          n_ait_sol,                           &
+                                          n_acc_sol,                           &
+                                          n_cor_sol,                           &
+                                          n_ait_ins,                           &
+                                          n_acc_ins,                           &
+                                          n_cor_ins,                           &
+                                          drydp_ait_sol,                       &
+                                          drydp_acc_sol,                       &
+                                          drydp_cor_sol,                       &
+                                          drydp_ait_ins,                       &
+                                          drydp_acc_ins,                       &
+                                          drydp_cor_ins )
+
+    use glomap_ccn_diag_kernel_mod, only: glomap_ccn_diag_kernel_type
+    use planet_config_mod,          only: p_zero, one_over_kappa
+
+    implicit none
+
+    type( field_type ), intent(in) :: theta_in_wth
+    type( field_type ), intent(in) :: exner_in_wth
+    type( field_type ), intent(in) :: n_ait_sol
+    type( field_type ), intent(in) :: n_acc_sol
+    type( field_type ), intent(in) :: n_cor_sol
+    type( field_type ), intent(in) :: n_ait_ins
+    type( field_type ), intent(in) :: n_acc_ins
+    type( field_type ), intent(in) :: n_cor_ins
+    type( field_type ), intent(in) :: drydp_ait_sol
+    type( field_type ), intent(in) :: drydp_acc_sol
+    type( field_type ), intent(in) :: drydp_cor_sol
+    type( field_type ), intent(in) :: drydp_ait_ins
+    type( field_type ), intent(in) :: drydp_acc_ins
+    type( field_type ), intent(in) :: drydp_cor_ins
+
+    type( field_type ) :: cn_number_conc
+    type( field_type ) :: ccn_number_conc_30nm
+    type( field_type ) :: ccn_number_conc_50nm
+
+    logical( kind=l_def ) :: cn_flag
+    logical( kind=l_def ) :: ccn_30nm_flag
+    logical( kind=l_def ) :: ccn_50nm_flag
+    logical( kind=l_def ) :: ignore
+
+    type( mesh_type ), pointer :: aerosol_mesh
+
+    !--------------------------------------------------------------------
+    ! End of declarations; start of subroutine execution
+    !--------------------------------------------------------------------
+
+    nullify(aerosol_mesh)
+
+    ! The aerosol scheme may run on a coarser mesh than the rest of the
+    ! model, so derive the mesh from an input field rather than from the
+    ! diagnostic metadata
+    aerosol_mesh => exner_in_wth%get_mesh()
+
+    cn_flag       = init_diag( cn_number_conc,                                 &
+                              'aerosol__cn_number_conc',                       &
+                               force_mesh = aerosol_mesh )
+    ccn_30nm_flag = init_diag( ccn_number_conc_30nm,                           &
+                              'aerosol__ccn_number_conc_30nm',                 &
+                               force_mesh = aerosol_mesh )
+    ccn_50nm_flag = init_diag( ccn_number_conc_50nm,                           &
+                              'aerosol__ccn_number_conc_50nm',                 &
+                               force_mesh = aerosol_mesh )
+
+    if ( cn_flag .or. ccn_30nm_flag .or. ccn_50nm_flag ) then
+
+      ! A single kernel call fills all three fields, so any field that was
+      ! not requested still has to be a real field rather than an empty one
+      if ( .not. cn_flag ) then
+        ignore = init_diag( cn_number_conc,                                    &
+                           'aerosol__cn_number_conc',                          &
+                            activate = .true.,                                 &
+                            force_mesh = aerosol_mesh )
+      end if
+      if ( .not. ccn_30nm_flag ) then
+        ignore = init_diag( ccn_number_conc_30nm,                              &
+                           'aerosol__ccn_number_conc_30nm',                    &
+                            activate = .true.,                                 &
+                            force_mesh = aerosol_mesh )
+      end if
+      if ( .not. ccn_50nm_flag ) then
+        ignore = init_diag( ccn_number_conc_50nm,                              &
+                           'aerosol__ccn_number_conc_50nm',                    &
+                            activate = .true.,                                 &
+                            force_mesh = aerosol_mesh )
+      end if
+
+      call invoke( glomap_ccn_diag_kernel_type( cn_number_conc,                &
+                                                ccn_number_conc_30nm,          &
+                                                ccn_number_conc_50nm,          &
+                                                p_zero,                        &
+                                                one_over_kappa,                &
+                                                theta_in_wth,                  &
+                                                exner_in_wth,                  &
+                                                n_ait_sol,                     &
+                                                n_acc_sol,                     &
+                                                n_cor_sol,                     &
+                                                n_ait_ins,                     &
+                                                n_acc_ins,                     &
+                                                n_cor_ins,                     &
+                                                drydp_ait_sol,                 &
+                                                drydp_acc_sol,                 &
+                                                drydp_cor_sol,                 &
+                                                drydp_ait_ins,                 &
+                                                drydp_acc_ins,                 &
+                                                drydp_cor_ins ) )
+
+      if ( cn_flag )       call cn_number_conc%write_field()
+      if ( ccn_30nm_flag ) call ccn_number_conc_30nm%write_field()
+      if ( ccn_50nm_flag ) call ccn_number_conc_50nm%write_field()
+
+    end if
+
+    nullify(aerosol_mesh)
+
+  end subroutine output_diags_for_glomap_ccn
+
+end module glomap_ccn_diags_mod

--- a/interfaces/physics_schemes_interface/source/diagnostics/glomap_ccn_diags_mod.x90
+++ b/interfaces/physics_schemes_interface/source/diagnostics/glomap_ccn_diags_mod.x90
@@ -30,13 +30,15 @@ contains
 
   !> @brief Compute and output the CN and CCN number concentrations and the
   !>        dust mass concentrations
-  !> @details Reproduces the UM diagnostics m01s38i437, m01s38i700 and
-  !>          m01s38i701 (number concentrations) and m01s38i502 and
-  !>          m01s38i503 (dust mass concentrations). The dry modal diameters
-  !>          are only refreshed on RADAER timesteps on the GLOMAP
-  !>          climatology path, so requesting the number concentrations more
-  !>          frequently than the RADAER call reuses the diameters of the
-  !>          most recent RADAER timestep.
+  !> @details The number concentrations count the particles per unit volume
+  !>          with a dry diameter above 3 nm (condensation nuclei), 30 nm and
+  !>          50 nm (cloud condensation nuclei), summed over the GLOMAP modes.
+  !>          The dust mass concentrations are the dust mass mixing ratios of
+  !>          the accumulation and coarse insoluble modes converted to mass
+  !>          per unit volume. The dry modal diameters are only refreshed on
+  !>          RADAER timesteps on the GLOMAP climatology path, so requesting
+  !>          the number concentrations more frequently than the RADAER call
+  !>          reuses the diameters of the most recent RADAER timestep.
   !> @param[in] theta_in_wth  Potential temperature field
   !> @param[in] exner_in_wth  Exner pressure in potential temperature space
   !> @param[in] n_ait_sol     Aitken soluble mode number mixing ratio

--- a/interfaces/physics_schemes_interface/source/diagnostics/glomap_ccn_diags_mod.x90
+++ b/interfaces/physics_schemes_interface/source/diagnostics/glomap_ccn_diags_mod.x90
@@ -5,9 +5,9 @@
 !-----------------------------------------------------------------------------
 
 !> @brief Processes the GLOMAP-mode condensation and cloud condensation
-!>        nuclei number concentration diagnostics.
-!> @details The three diagnostics are derived from the aerosol size
-!>          distribution rather than being scheme outputs, so they are
+!>        nuclei number concentration and dust mass concentration diagnostics.
+!> @details The diagnostics are derived from the aerosol size distribution
+!>          and composition rather than being scheme outputs, so they are
 !>          computed at output time and only when at least one of them has
 !>          been requested. The same routine serves both the GLOMAP
 !>          climatology and the prognostic UKCA paths.
@@ -27,12 +27,15 @@ module glomap_ccn_diags_mod
 
 contains
 
-  !> @brief Compute and output the CN and CCN number concentrations
+  !> @brief Compute and output the CN and CCN number concentrations and the
+  !>        dust mass concentrations
   !> @details Reproduces the UM diagnostics m01s38i437, m01s38i700 and
-  !>          m01s38i701. The dry modal diameters are only refreshed on
-  !>          RADAER timesteps on the GLOMAP climatology path, so requesting
-  !>          these diagnostics more frequently than the RADAER call reuses
-  !>          the diameters of the most recent RADAER timestep.
+  !>          m01s38i701 (number concentrations) and m01s38i502 and
+  !>          m01s38i503 (dust mass concentrations). The dry modal diameters
+  !>          are only refreshed on RADAER timesteps on the GLOMAP
+  !>          climatology path, so requesting the number concentrations more
+  !>          frequently than the RADAER call reuses the diameters of the
+  !>          most recent RADAER timestep.
   !> @param[in] theta_in_wth  Potential temperature field
   !> @param[in] exner_in_wth  Exner pressure in potential temperature space
   !> @param[in] n_ait_sol     Aitken soluble mode number mixing ratio
@@ -47,6 +50,9 @@ contains
   !> @param[in] drydp_ait_ins Aitken insoluble mode dry modal diameter
   !> @param[in] drydp_acc_ins Accumulation insoluble mode dry modal diameter
   !> @param[in] drydp_cor_ins Coarse insoluble mode dry modal diameter
+  !> @param[in] acc_ins_du    Accumulation insoluble mode dust mass mixing
+  !!                          ratio
+  !> @param[in] cor_ins_du    Coarse insoluble mode dust mass mixing ratio
   subroutine output_diags_for_glomap_ccn( theta_in_wth,                        &
                                           exner_in_wth,                        &
                                           n_ait_sol,                           &
@@ -60,10 +66,12 @@ contains
                                           drydp_cor_sol,                       &
                                           drydp_ait_ins,                       &
                                           drydp_acc_ins,                       &
-                                          drydp_cor_ins )
+                                          drydp_cor_ins,                       &
+                                          acc_ins_du,                          &
+                                          cor_ins_du )
 
     use glomap_ccn_diag_kernel_mod, only: glomap_ccn_diag_kernel_type
-    use planet_config_mod,          only: p_zero, one_over_kappa
+    use planet_config_mod,          only: p_zero, one_over_kappa, rd
 
     implicit none
 
@@ -81,14 +89,20 @@ contains
     type( field_type ), intent(in) :: drydp_ait_ins
     type( field_type ), intent(in) :: drydp_acc_ins
     type( field_type ), intent(in) :: drydp_cor_ins
+    type( field_type ), intent(in) :: acc_ins_du
+    type( field_type ), intent(in) :: cor_ins_du
 
     type( field_type ) :: cn_number_conc
     type( field_type ) :: ccn_number_conc_30nm
     type( field_type ) :: ccn_number_conc_50nm
+    type( field_type ) :: mconc_du_acc_ins
+    type( field_type ) :: mconc_du_cor_ins
 
     logical( kind=l_def ) :: cn_flag
     logical( kind=l_def ) :: ccn_30nm_flag
     logical( kind=l_def ) :: ccn_50nm_flag
+    logical( kind=l_def ) :: du_acc_ins_flag
+    logical( kind=l_def ) :: du_cor_ins_flag
     logical( kind=l_def ) :: ignore
 
     type( mesh_type ), pointer :: aerosol_mesh
@@ -113,10 +127,17 @@ contains
     ccn_50nm_flag = init_diag( ccn_number_conc_50nm,                           &
                               'aerosol__ccn_number_conc_50nm',                 &
                                force_mesh = aerosol_mesh )
+    du_acc_ins_flag = init_diag( mconc_du_acc_ins,                             &
+                                'aerosol__mconc_du_acc_ins',                   &
+                                 force_mesh = aerosol_mesh )
+    du_cor_ins_flag = init_diag( mconc_du_cor_ins,                             &
+                                'aerosol__mconc_du_cor_ins',                   &
+                                 force_mesh = aerosol_mesh )
 
-    if ( cn_flag .or. ccn_30nm_flag .or. ccn_50nm_flag ) then
+    if ( cn_flag .or. ccn_30nm_flag .or. ccn_50nm_flag .or.                    &
+         du_acc_ins_flag .or. du_cor_ins_flag ) then
 
-      ! A single kernel call fills all three fields, so any field that was
+      ! A single kernel call fills all five fields, so any field that was
       ! not requested still has to be a real field rather than an empty one
       if ( .not. cn_flag ) then
         ignore = init_diag( cn_number_conc,                                    &
@@ -136,12 +157,27 @@ contains
                             activate = .true.,                                 &
                             force_mesh = aerosol_mesh )
       end if
+      if ( .not. du_acc_ins_flag ) then
+        ignore = init_diag( mconc_du_acc_ins,                                  &
+                           'aerosol__mconc_du_acc_ins',                        &
+                            activate = .true.,                                 &
+                            force_mesh = aerosol_mesh )
+      end if
+      if ( .not. du_cor_ins_flag ) then
+        ignore = init_diag( mconc_du_cor_ins,                                  &
+                           'aerosol__mconc_du_cor_ins',                        &
+                            activate = .true.,                                 &
+                            force_mesh = aerosol_mesh )
+      end if
 
       call invoke( glomap_ccn_diag_kernel_type( cn_number_conc,                &
                                                 ccn_number_conc_30nm,          &
                                                 ccn_number_conc_50nm,          &
+                                                mconc_du_acc_ins,              &
+                                                mconc_du_cor_ins,              &
                                                 p_zero,                        &
                                                 one_over_kappa,                &
+                                                rd,                            &
                                                 theta_in_wth,                  &
                                                 exner_in_wth,                  &
                                                 n_ait_sol,                     &
@@ -155,11 +191,15 @@ contains
                                                 drydp_cor_sol,                 &
                                                 drydp_ait_ins,                 &
                                                 drydp_acc_ins,                 &
-                                                drydp_cor_ins ) )
+                                                drydp_cor_ins,                 &
+                                                acc_ins_du,                    &
+                                                cor_ins_du ) )
 
-      if ( cn_flag )       call cn_number_conc%write_field()
-      if ( ccn_30nm_flag ) call ccn_number_conc_30nm%write_field()
-      if ( ccn_50nm_flag ) call ccn_number_conc_50nm%write_field()
+      if ( cn_flag )         call cn_number_conc%write_field()
+      if ( ccn_30nm_flag )   call ccn_number_conc_30nm%write_field()
+      if ( ccn_50nm_flag )   call ccn_number_conc_50nm%write_field()
+      if ( du_acc_ins_flag ) call mconc_du_acc_ins%write_field()
+      if ( du_cor_ins_flag ) call mconc_du_cor_ins%write_field()
 
     end if
 

--- a/interfaces/physics_schemes_interface/source/diagnostics/glomap_ccn_diags_mod.x90
+++ b/interfaces/physics_schemes_interface/source/diagnostics/glomap_ccn_diags_mod.x90
@@ -34,13 +34,14 @@ contains
   !>          with a dry diameter above 3 nm (condensation nuclei), 30 nm and
   !>          50 nm (cloud condensation nuclei), summed over the GLOMAP modes.
   !>          The dust mass concentrations are the dust mass mixing ratios of
-  !>          the accumulation and coarse insoluble modes converted to mass
-  !>          per unit volume. The dry modal diameters are only refreshed on
+  !>          the accumulation and coarse insoluble modes multiplied by the
+  !>          dry air density. The dry modal diameters are only refreshed on
   !>          RADAER timesteps on the GLOMAP climatology path, so requesting
   !>          the number concentrations more frequently than the RADAER call
   !>          reuses the diameters of the most recent RADAER timestep.
   !> @param[in] theta_in_wth  Potential temperature field
   !> @param[in] exner_in_wth  Exner pressure in potential temperature space
+  !> @param[in] rho_in_wth    Dry air density in potential temperature space
   !> @param[in] n_ait_sol     Aitken soluble mode number mixing ratio
   !> @param[in] n_acc_sol     Accumulation soluble mode number mixing ratio
   !> @param[in] n_cor_sol     Coarse soluble mode number mixing ratio
@@ -58,6 +59,7 @@ contains
   !> @param[in] cor_ins_du    Coarse insoluble mode dust mass mixing ratio
   subroutine output_diags_for_glomap_ccn( theta_in_wth,                        &
                                           exner_in_wth,                        &
+                                          rho_in_wth,                          &
                                           n_ait_sol,                           &
                                           n_acc_sol,                           &
                                           n_cor_sol,                           &
@@ -74,12 +76,13 @@ contains
                                           cor_ins_du )
 
     use glomap_ccn_diag_kernel_mod, only: glomap_ccn_diag_kernel_type
-    use planet_config_mod,          only: p_zero, one_over_kappa, rd
+    use planet_config_mod,          only: p_zero, one_over_kappa
 
     implicit none
 
     type( field_type ), intent(in) :: theta_in_wth
     type( field_type ), intent(in) :: exner_in_wth
+    type( field_type ), intent(in) :: rho_in_wth
     type( field_type ), intent(in) :: n_ait_sol
     type( field_type ), intent(in) :: n_acc_sol
     type( field_type ), intent(in) :: n_cor_sol
@@ -145,9 +148,9 @@ contains
                                               mconc_du_cor_ins,              &
                                               p_zero,                        &
                                               one_over_kappa,                &
-                                              rd,                            &
                                               theta_in_wth,                  &
                                               exner_in_wth,                  &
+                                              rho_in_wth,                    &
                                               n_ait_sol,                     &
                                               n_acc_sol,                     &
                                               n_cor_sol,                     &

--- a/interfaces/physics_schemes_interface/source/diagnostics/glomap_ccn_diags_mod.x90
+++ b/interfaces/physics_schemes_interface/source/diagnostics/glomap_ccn_diags_mod.x90
@@ -8,9 +8,10 @@
 !>        nuclei number concentration and dust mass concentration diagnostics.
 !> @details The diagnostics are derived from the aerosol size distribution
 !>          and composition rather than being scheme outputs, so they are
-!>          computed at output time and only when at least one of them has
-!>          been requested. The same routine serves both the GLOMAP
-!>          climatology and the prognostic UKCA paths.
+!>          computed at output time. Fields that have not been requested
+!>          are left as empty-data fields, which the kernel detects and
+!>          skips. The same routine serves both the GLOMAP climatology and
+!>          the prognostic UKCA paths.
 
 module glomap_ccn_diags_mod
 
@@ -103,7 +104,6 @@ contains
     logical( kind=l_def ) :: ccn_50nm_flag
     logical( kind=l_def ) :: du_acc_ins_flag
     logical( kind=l_def ) :: du_cor_ins_flag
-    logical( kind=l_def ) :: ignore
 
     type( mesh_type ), pointer :: aerosol_mesh
 
@@ -134,74 +134,38 @@ contains
                                 'aerosol__mconc_du_cor_ins',                   &
                                  force_mesh = aerosol_mesh )
 
-    if ( cn_flag .or. ccn_30nm_flag .or. ccn_50nm_flag .or.                    &
-         du_acc_ins_flag .or. du_cor_ins_flag ) then
+    ! The kernel fills only the fields that carry real data; the others
+    ! still point at the shared empty data array and are left untouched
+    call invoke( glomap_ccn_diag_kernel_type( cn_number_conc,                &
+                                              ccn_number_conc_30nm,          &
+                                              ccn_number_conc_50nm,          &
+                                              mconc_du_acc_ins,              &
+                                              mconc_du_cor_ins,              &
+                                              p_zero,                        &
+                                              one_over_kappa,                &
+                                              rd,                            &
+                                              theta_in_wth,                  &
+                                              exner_in_wth,                  &
+                                              n_ait_sol,                     &
+                                              n_acc_sol,                     &
+                                              n_cor_sol,                     &
+                                              n_ait_ins,                     &
+                                              n_acc_ins,                     &
+                                              n_cor_ins,                     &
+                                              drydp_ait_sol,                 &
+                                              drydp_acc_sol,                 &
+                                              drydp_cor_sol,                 &
+                                              drydp_ait_ins,                 &
+                                              drydp_acc_ins,                 &
+                                              drydp_cor_ins,                 &
+                                              acc_ins_du,                    &
+                                              cor_ins_du ) )
 
-      ! A single kernel call fills all five fields, so any field that was
-      ! not requested still has to be a real field rather than an empty one
-      if ( .not. cn_flag ) then
-        ignore = init_diag( cn_number_conc,                                    &
-                           'aerosol__cn_number_conc',                          &
-                            activate = .true.,                                 &
-                            force_mesh = aerosol_mesh )
-      end if
-      if ( .not. ccn_30nm_flag ) then
-        ignore = init_diag( ccn_number_conc_30nm,                              &
-                           'aerosol__ccn_number_conc_30nm',                    &
-                            activate = .true.,                                 &
-                            force_mesh = aerosol_mesh )
-      end if
-      if ( .not. ccn_50nm_flag ) then
-        ignore = init_diag( ccn_number_conc_50nm,                              &
-                           'aerosol__ccn_number_conc_50nm',                    &
-                            activate = .true.,                                 &
-                            force_mesh = aerosol_mesh )
-      end if
-      if ( .not. du_acc_ins_flag ) then
-        ignore = init_diag( mconc_du_acc_ins,                                  &
-                           'aerosol__mconc_du_acc_ins',                        &
-                            activate = .true.,                                 &
-                            force_mesh = aerosol_mesh )
-      end if
-      if ( .not. du_cor_ins_flag ) then
-        ignore = init_diag( mconc_du_cor_ins,                                  &
-                           'aerosol__mconc_du_cor_ins',                        &
-                            activate = .true.,                                 &
-                            force_mesh = aerosol_mesh )
-      end if
-
-      call invoke( glomap_ccn_diag_kernel_type( cn_number_conc,                &
-                                                ccn_number_conc_30nm,          &
-                                                ccn_number_conc_50nm,          &
-                                                mconc_du_acc_ins,              &
-                                                mconc_du_cor_ins,              &
-                                                p_zero,                        &
-                                                one_over_kappa,                &
-                                                rd,                            &
-                                                theta_in_wth,                  &
-                                                exner_in_wth,                  &
-                                                n_ait_sol,                     &
-                                                n_acc_sol,                     &
-                                                n_cor_sol,                     &
-                                                n_ait_ins,                     &
-                                                n_acc_ins,                     &
-                                                n_cor_ins,                     &
-                                                drydp_ait_sol,                 &
-                                                drydp_acc_sol,                 &
-                                                drydp_cor_sol,                 &
-                                                drydp_ait_ins,                 &
-                                                drydp_acc_ins,                 &
-                                                drydp_cor_ins,                 &
-                                                acc_ins_du,                    &
-                                                cor_ins_du ) )
-
-      if ( cn_flag )         call cn_number_conc%write_field()
-      if ( ccn_30nm_flag )   call ccn_number_conc_30nm%write_field()
-      if ( ccn_50nm_flag )   call ccn_number_conc_50nm%write_field()
-      if ( du_acc_ins_flag ) call mconc_du_acc_ins%write_field()
-      if ( du_cor_ins_flag ) call mconc_du_cor_ins%write_field()
-
-    end if
+    if ( cn_flag )         call cn_number_conc%write_field()
+    if ( ccn_30nm_flag )   call ccn_number_conc_30nm%write_field()
+    if ( ccn_50nm_flag )   call ccn_number_conc_50nm%write_field()
+    if ( du_acc_ins_flag ) call mconc_du_acc_ins%write_field()
+    if ( du_cor_ins_flag ) call mconc_du_cor_ins%write_field()
 
     nullify(aerosol_mesh)
 

--- a/interfaces/physics_schemes_interface/source/kernel/glomap_ccn_diag_kernel_mod.F90
+++ b/interfaces/physics_schemes_interface/source/kernel/glomap_ccn_diag_kernel_mod.F90
@@ -1,0 +1,294 @@
+!-----------------------------------------------------------------------------
+! (C) Crown copyright Met Office. All rights reserved.
+! The file LICENCE, distributed with this code, contains details of the terms
+! under which the code may be used.
+!-----------------------------------------------------------------------------
+!> @brief Condensation and cloud condensation nuclei number concentrations
+!>        from the GLOMAP-mode aerosol size distribution.
+!>
+!> @details Each GLOMAP mode is a lognormal distribution of dry particle
+!>          diameter with geometric mean diameter drydp and fixed geometric
+!>          standard deviation sigmag. The number of particles per unit
+!>          volume with a dry diameter larger than a threshold dp0 is
+!>          therefore available analytically as
+!>
+!>            0.5 * nd * ( 1 - erf( ln(dp0/drydp) / (sqrt(2)*ln(sigmag)) ) )
+!>
+!>          summed over the modes. This reproduces the UM/UKCA diagnostics
+!>          m01s38i437 (dp0 = 3 nm), m01s38i700 (dp0 = 30 nm) and
+!>          m01s38i701 (dp0 = 50 nm), computed in ukca_aero_ctl.
+!>
+!>          Only the six modes that carry a dry modal diameter in LFRic are
+!>          summed. The nucleation-soluble mode is omitted because LFRic has
+!>          no drydp_nuc_sol field; its contribution is negligible at the
+!>          30 nm and 50 nm thresholds but not at 3 nm, so the condensation
+!>          nuclei count is a low estimate under prognostic UKCA.
+
+module glomap_ccn_diag_kernel_mod
+
+  use argument_mod,      only: arg_type,          &
+                               GH_FIELD, GH_REAL, &
+                               GH_SCALAR,         &
+                               GH_READ, GH_WRITE, &
+                               CELL_COLUMN
+
+  use fs_continuity_mod, only: WTHETA
+
+  use kernel_mod,        only: kernel_type
+
+  implicit none
+
+  private
+
+  !---------------------------------------------------------------------------
+  ! Public types
+  !---------------------------------------------------------------------------
+  !> The type declaration for the kernel.
+  !> Contains the metadata needed by the Psy layer
+
+  type, public, extends(kernel_type) :: glomap_ccn_diag_kernel_type
+    private
+    type(arg_type) :: meta_args(19) = (/                &
+         arg_type(GH_FIELD,  GH_REAL, GH_WRITE, WTHETA), & ! cn_number_conc
+         arg_type(GH_FIELD,  GH_REAL, GH_WRITE, WTHETA), & ! ccn_no_conc_30nm
+         arg_type(GH_FIELD,  GH_REAL, GH_WRITE, WTHETA), & ! ccn_no_conc_50nm
+         arg_type(GH_SCALAR, GH_REAL, GH_READ),          & ! p_zero
+         arg_type(GH_SCALAR, GH_REAL, GH_READ),          & ! one_over_kappa
+         arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! theta_in_wth
+         arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! exner_in_wth
+         arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! n_ait_sol
+         arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! n_acc_sol
+         arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! n_cor_sol
+         arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! n_ait_ins
+         arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! n_acc_ins
+         arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! n_cor_ins
+         arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! drydp_ait_sol
+         arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! drydp_acc_sol
+         arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! drydp_cor_sol
+         arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! drydp_ait_ins
+         arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! drydp_acc_ins
+         arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA)  & ! drydp_cor_ins
+         /)
+    integer :: operates_on = CELL_COLUMN
+  contains
+    procedure, nopass :: glomap_ccn_diag_code
+  end type glomap_ccn_diag_kernel_type
+
+  public :: glomap_ccn_diag_code
+
+contains
+
+!> @brief Sum the lognormal tail of each GLOMAP mode above three dry diameter
+!>        thresholds to give condensation and cloud condensation nuclei counts.
+!> @param[in]     nlayers              The number of layers
+!> @param[in,out] cn_number_conc       Condensation nuclei number
+!!                                      concentration, dry diameter > 3 nm
+!> @param[in,out] ccn_number_conc_30nm Cloud condensation nuclei number
+!!                                      concentration, dry diameter > 30 nm
+!> @param[in,out] ccn_number_conc_50nm Cloud condensation nuclei number
+!!                                      concentration, dry diameter > 50 nm
+!> @param[in]     p_zero               Reference surface pressure
+!> @param[in]     one_over_kappa       Reciprocal of the ratio of the gas
+!!                                      constant to the specific heat
+!> @param[in]     theta_in_wth         Potential temperature field
+!> @param[in]     exner_in_wth         Exner pressure in potential
+!!                                      temperature space
+!> @param[in]     n_ait_sol            Aitken soluble mode number mixing ratio
+!> @param[in]     n_acc_sol            Accumulation soluble mode number
+!!                                      mixing ratio
+!> @param[in]     n_cor_sol            Coarse soluble mode number mixing ratio
+!> @param[in]     n_ait_ins            Aitken insoluble mode number
+!!                                      mixing ratio
+!> @param[in]     n_acc_ins            Accumulation insoluble mode number
+!!                                      mixing ratio
+!> @param[in]     n_cor_ins            Coarse insoluble mode number
+!!                                      mixing ratio
+!> @param[in]     drydp_ait_sol        Aitken soluble mode dry diameter
+!> @param[in]     drydp_acc_sol        Accumulation soluble mode dry diameter
+!> @param[in]     drydp_cor_sol        Coarse soluble mode dry diameter
+!> @param[in]     drydp_ait_ins        Aitken insoluble mode dry diameter
+!> @param[in]     drydp_acc_ins        Accumulation insoluble mode dry diameter
+!> @param[in]     drydp_cor_ins        Coarse insoluble mode dry diameter
+!> @param[in]     ndf_wth              Number of degrees of freedom per cell
+!!                                      for the potential temperature space
+!> @param[in]     undf_wth             Number of unique degrees of freedom
+!!                                      for the potential temperature space
+!> @param[in]     map_wth              Dofmap for the cell at the base of the
+!!                                      column for the potential temperature
+!!                                      space
+subroutine glomap_ccn_diag_code( nlayers,                                      &
+                                 cn_number_conc,                               &
+                                 ccn_number_conc_30nm,                         &
+                                 ccn_number_conc_50nm,                         &
+                                 p_zero,                                       &
+                                 one_over_kappa,                               &
+                                 theta_in_wth,                                 &
+                                 exner_in_wth,                                 &
+                                 n_ait_sol,                                    &
+                                 n_acc_sol,                                    &
+                                 n_cor_sol,                                    &
+                                 n_ait_ins,                                    &
+                                 n_acc_ins,                                    &
+                                 n_cor_ins,                                    &
+                                 drydp_ait_sol,                                &
+                                 drydp_acc_sol,                                &
+                                 drydp_cor_sol,                                &
+                                 drydp_ait_ins,                                &
+                                 drydp_acc_ins,                                &
+                                 drydp_cor_ins,                                &
+                                 ndf_wth, undf_wth, map_wth )
+
+  use constants_mod,                   only: r_def, i_def
+  use science_chemistry_constants_mod, only: boltzmann
+
+  implicit none
+
+  ! Arguments
+
+  integer(kind=i_def), intent(in) :: nlayers
+
+  integer(kind=i_def), intent(in) :: ndf_wth
+  integer(kind=i_def), intent(in) :: undf_wth
+  integer(kind=i_def), dimension(ndf_wth), intent(in) :: map_wth
+
+  real(kind=r_def), intent(inout), dimension(undf_wth) :: cn_number_conc
+  real(kind=r_def), intent(inout), dimension(undf_wth) :: ccn_number_conc_30nm
+  real(kind=r_def), intent(inout), dimension(undf_wth) :: ccn_number_conc_50nm
+
+  real(kind=r_def), intent(in) :: p_zero
+  real(kind=r_def), intent(in) :: one_over_kappa
+
+  real(kind=r_def), intent(in), dimension(undf_wth) :: theta_in_wth
+  real(kind=r_def), intent(in), dimension(undf_wth) :: exner_in_wth
+  real(kind=r_def), intent(in), dimension(undf_wth) :: n_ait_sol
+  real(kind=r_def), intent(in), dimension(undf_wth) :: n_acc_sol
+  real(kind=r_def), intent(in), dimension(undf_wth) :: n_cor_sol
+  real(kind=r_def), intent(in), dimension(undf_wth) :: n_ait_ins
+  real(kind=r_def), intent(in), dimension(undf_wth) :: n_acc_ins
+  real(kind=r_def), intent(in), dimension(undf_wth) :: n_cor_ins
+  real(kind=r_def), intent(in), dimension(undf_wth) :: drydp_ait_sol
+  real(kind=r_def), intent(in), dimension(undf_wth) :: drydp_acc_sol
+  real(kind=r_def), intent(in), dimension(undf_wth) :: drydp_cor_sol
+  real(kind=r_def), intent(in), dimension(undf_wth) :: drydp_ait_ins
+  real(kind=r_def), intent(in), dimension(undf_wth) :: drydp_acc_ins
+  real(kind=r_def), intent(in), dimension(undf_wth) :: drydp_cor_ins
+
+  ! Internal variables
+
+  ! The six GLOMAP modes that carry a dry modal diameter in LFRic, ordered
+  ! aitken soluble, accumulation soluble, coarse soluble, aitken insoluble,
+  ! accumulation insoluble, coarse insoluble
+  integer(kind=i_def), parameter :: nmodes_diag = 6
+
+  ! Geometric standard deviation of each mode, taken from the UKCA 7-mode
+  ! setup i_sussbcocdu_7mode (ukca_mode_setup sigmag), with the leading
+  ! nucleation-soluble entry dropped
+  real(kind=r_def), parameter :: sigmag(nmodes_diag) =                        &
+      (/ 1.59_r_def, 1.40_r_def, 2.00_r_def,                                  &
+         1.59_r_def, 1.59_r_def, 2.00_r_def /)
+
+  ! Dry diameter thresholds of the three diagnostics (m)
+  real(kind=r_def), parameter :: dp0_cn   =  3.0e-9_r_def
+  real(kind=r_def), parameter :: dp0_30nm = 30.0e-9_r_def
+  real(kind=r_def), parameter :: dp0_50nm = 50.0e-9_r_def
+
+  ! Smallest dry diameter admitted, well below any physical particle size.
+  ! Guards the logarithm against unset diameters, which are left at zero
+  ! until the first RADAER timestep on the climatology path.
+  real(kind=r_def), parameter :: drydp_min = 1.0e-12_r_def
+
+  ! Number of cubic centimetres in a cubic metre
+  real(kind=r_def), parameter :: m3_to_cm3 = 1.0e+6_r_def
+
+  ! Square root of two, written out for portability of constant
+  ! expressions across compilers
+  real(kind=r_def), parameter :: root_two = 1.4142135623730951_r_def
+
+  ! Reciprocal of sqrt(2)*ln(sigmag) for each mode
+  real(kind=r_def), dimension(nmodes_diag) :: recip_width
+
+  ! Number mixing ratio and dry modal diameter of each mode at one level
+  real(kind=r_def), dimension(nmodes_diag) :: number_mr
+  real(kind=r_def), dimension(nmodes_diag) :: drydp
+
+  real(kind=r_def) :: exner_k        ! Exner pressure at this level
+  real(kind=r_def) :: air_num_dens   ! Number density of air (cm-3)
+  real(kind=r_def) :: number_conc    ! Number concentration of a mode (cm-3)
+  real(kind=r_def) :: cn_sum         ! Running sum for dry diameter > 3 nm
+  real(kind=r_def) :: ccn_30nm_sum   ! Running sum for dry diameter > 30 nm
+  real(kind=r_def) :: ccn_50nm_sum   ! Running sum for dry diameter > 50 nm
+
+  integer(kind=i_def) :: k, imode
+
+  !---------------------------------------------------------------------------
+  ! Lognormal width of each mode, which does not vary in the column
+  !---------------------------------------------------------------------------
+
+  do imode = 1, nmodes_diag
+    recip_width(imode) = 1.0_r_def / ( root_two * log( sigmag(imode) ) )
+  end do
+
+  !---------------------------------------------------------------------------
+  ! Sum the tail of each mode above the three thresholds
+  !---------------------------------------------------------------------------
+
+  do k = 1, nlayers
+
+    ! Number density of air from pressure and temperature, matching
+    ! aird in ukca_mode_diags_mod
+    exner_k = exner_in_wth(map_wth(1) + k)
+    air_num_dens = p_zero * exner_k**one_over_kappa                           &
+                 / ( exner_k * theta_in_wth(map_wth(1) + k)                   &
+                     * boltzmann * m3_to_cm3 )
+
+    number_mr(1) = n_ait_sol(map_wth(1) + k)
+    number_mr(2) = n_acc_sol(map_wth(1) + k)
+    number_mr(3) = n_cor_sol(map_wth(1) + k)
+    number_mr(4) = n_ait_ins(map_wth(1) + k)
+    number_mr(5) = n_acc_ins(map_wth(1) + k)
+    number_mr(6) = n_cor_ins(map_wth(1) + k)
+
+    drydp(1) = max( drydp_ait_sol(map_wth(1) + k), drydp_min )
+    drydp(2) = max( drydp_acc_sol(map_wth(1) + k), drydp_min )
+    drydp(3) = max( drydp_cor_sol(map_wth(1) + k), drydp_min )
+    drydp(4) = max( drydp_ait_ins(map_wth(1) + k), drydp_min )
+    drydp(5) = max( drydp_acc_ins(map_wth(1) + k), drydp_min )
+    drydp(6) = max( drydp_cor_ins(map_wth(1) + k), drydp_min )
+
+    cn_sum       = 0.0_r_def
+    ccn_30nm_sum = 0.0_r_def
+    ccn_50nm_sum = 0.0_r_def
+
+    do imode = 1, nmodes_diag
+
+      ! Number mixing ratios are per air molecule, so scaling by the air
+      ! number density gives particles per cubic centimetre
+      number_conc = number_mr(imode) * air_num_dens
+
+      cn_sum = cn_sum + 0.5_r_def * number_conc * ( 1.0_r_def -               &
+          erf( log( dp0_cn / drydp(imode) ) * recip_width(imode) ) )
+
+      ccn_30nm_sum = ccn_30nm_sum + 0.5_r_def * number_conc * ( 1.0_r_def -   &
+          erf( log( dp0_30nm / drydp(imode) ) * recip_width(imode) ) )
+
+      ccn_50nm_sum = ccn_50nm_sum + 0.5_r_def * number_conc * ( 1.0_r_def -   &
+          erf( log( dp0_50nm / drydp(imode) ) * recip_width(imode) ) )
+
+    end do
+
+    cn_number_conc(map_wth(1) + k)       = cn_sum
+    ccn_number_conc_30nm(map_wth(1) + k) = ccn_30nm_sum
+    ccn_number_conc_50nm(map_wth(1) + k) = ccn_50nm_sum
+
+  end do
+
+  ! The zeroth level is redundant for the GLOMAP fields, so set it to the
+  ! same as the first level. It appears in the diagnostic output but is not
+  ! used in model evolution.
+  cn_number_conc(map_wth(1))       = cn_number_conc(map_wth(1) + 1)
+  ccn_number_conc_30nm(map_wth(1)) = ccn_number_conc_30nm(map_wth(1) + 1)
+  ccn_number_conc_50nm(map_wth(1)) = ccn_number_conc_50nm(map_wth(1) + 1)
+
+end subroutine glomap_ccn_diag_code
+
+end module glomap_ccn_diag_kernel_mod

--- a/interfaces/physics_schemes_interface/source/kernel/glomap_ccn_diag_kernel_mod.F90
+++ b/interfaces/physics_schemes_interface/source/kernel/glomap_ccn_diag_kernel_mod.F90
@@ -30,6 +30,10 @@
 !>          the air density p / (Rd * T). They are computed here rather than
 !>          as an XIOS expression so that every operand is on the aerosol
 !>          mesh and uses the same pressure and temperature as UKCA.
+!>
+!>          Every output field is only populated when it has been requested
+!>          as a diagnostic; unrequested fields share the empty data array
+!>          and are left untouched.
 
 module glomap_ccn_diag_kernel_mod
 
@@ -42,6 +46,8 @@ module glomap_ccn_diag_kernel_mod
   use fs_continuity_mod, only: WTHETA
 
   use kernel_mod,        only: kernel_type
+
+  use empty_data_mod,    only: empty_real_data
 
   implicit none
 
@@ -178,11 +184,13 @@ subroutine glomap_ccn_diag_code( nlayers,                                      &
   integer(kind=i_def), intent(in) :: undf_wth
   integer(kind=i_def), dimension(ndf_wth), intent(in) :: map_wth
 
-  real(kind=r_def), intent(inout), dimension(undf_wth) :: cn_number_conc
-  real(kind=r_def), intent(inout), dimension(undf_wth) :: ccn_number_conc_30nm
-  real(kind=r_def), intent(inout), dimension(undf_wth) :: ccn_number_conc_50nm
-  real(kind=r_def), intent(inout), dimension(undf_wth) :: mconc_du_acc_ins
-  real(kind=r_def), intent(inout), dimension(undf_wth) :: mconc_du_cor_ins
+  ! Diagnostic outputs, which point at the shared empty data array when
+  ! the diagnostic has not been requested
+  real(kind=r_def), pointer, dimension(:), intent(inout) :: cn_number_conc
+  real(kind=r_def), pointer, dimension(:), intent(inout) :: ccn_number_conc_30nm
+  real(kind=r_def), pointer, dimension(:), intent(inout) :: ccn_number_conc_50nm
+  real(kind=r_def), pointer, dimension(:), intent(inout) :: mconc_du_acc_ins
+  real(kind=r_def), pointer, dimension(:), intent(inout) :: mconc_du_cor_ins
 
   real(kind=r_def), intent(in) :: p_zero
   real(kind=r_def), intent(in) :: one_over_kappa
@@ -239,8 +247,8 @@ subroutine glomap_ccn_diag_code( nlayers,                                      &
   ! Reciprocal of sqrt(2)*ln(sigmag) for each mode
   real(kind=r_def), dimension(nmodes_diag) :: recip_width
 
-  ! Number mixing ratio and dry modal diameter of each mode at one level
-  real(kind=r_def), dimension(nmodes_diag) :: number_mr
+  ! Number concentration and dry modal diameter of each mode at one level
+  real(kind=r_def), dimension(nmodes_diag) :: number_conc
   real(kind=r_def), dimension(nmodes_diag) :: drydp
 
   real(kind=r_def) :: exner_k        ! Exner pressure at this level
@@ -248,24 +256,42 @@ subroutine glomap_ccn_diag_code( nlayers,                                      &
   real(kind=r_def) :: temperature    ! Temperature at this level (K)
   real(kind=r_def) :: air_dens       ! Mass density of air (kg m-3)
   real(kind=r_def) :: air_num_dens   ! Number density of air (cm-3)
-  real(kind=r_def) :: number_conc    ! Number concentration of a mode (cm-3)
-  real(kind=r_def) :: cn_sum         ! Running sum for dry diameter > 3 nm
-  real(kind=r_def) :: ccn_30nm_sum   ! Running sum for dry diameter > 30 nm
-  real(kind=r_def) :: ccn_50nm_sum   ! Running sum for dry diameter > 50 nm
+  real(kind=r_def) :: tail_sum       ! Running sum over the modes
+
+  ! Which diagnostics have real data behind them
+  logical :: l_cn
+  logical :: l_ccn_30nm
+  logical :: l_ccn_50nm
+  logical :: l_du_acc_ins
+  logical :: l_du_cor_ins
+  logical :: l_number_conc
 
   integer(kind=i_def) :: k, imode
+
+  !---------------------------------------------------------------------------
+  ! Determine which diagnostics have been requested
+  !---------------------------------------------------------------------------
+
+  l_cn         = .not. associated( cn_number_conc,       empty_real_data )
+  l_ccn_30nm   = .not. associated( ccn_number_conc_30nm, empty_real_data )
+  l_ccn_50nm   = .not. associated( ccn_number_conc_50nm, empty_real_data )
+  l_du_acc_ins = .not. associated( mconc_du_acc_ins,     empty_real_data )
+  l_du_cor_ins = .not. associated( mconc_du_cor_ins,     empty_real_data )
+
+  l_number_conc = l_cn .or. l_ccn_30nm .or. l_ccn_50nm
 
   !---------------------------------------------------------------------------
   ! Lognormal width of each mode, which does not vary in the column
   !---------------------------------------------------------------------------
 
-  do imode = 1, nmodes_diag
-    recip_width(imode) = 1.0_r_def / ( root_two * log( sigmag(imode) ) )
-  end do
+  if ( l_number_conc ) then
+    do imode = 1, nmodes_diag
+      recip_width(imode) = 1.0_r_def / ( root_two * log( sigmag(imode) ) )
+    end do
+  end if
 
   !---------------------------------------------------------------------------
-  ! Sum the tail of each mode above the three thresholds, and convert the
-  ! dust mass mixing ratios to mass concentrations
+  ! Column loop
   !---------------------------------------------------------------------------
 
   do k = 1, nlayers
@@ -274,66 +300,112 @@ subroutine glomap_ccn_diag_code( nlayers,                                      &
     pressure    = p_zero * exner_k**one_over_kappa
     temperature = exner_k * theta_in_wth(map_wth(1) + k)
 
-    ! Number density of air from pressure and temperature, matching
-    ! aird in ukca_mode_diags_mod
-    air_num_dens = pressure / ( temperature * boltzmann * m3_to_cm3 )
+    !-------------------------------------------------------------------------
+    ! Number concentrations above each dry diameter threshold
+    !-------------------------------------------------------------------------
 
-    ! Mass density of dry air, as used for the UKCA component mass
-    ! concentrations in ukca_mode_diags_mod
-    air_dens = pressure / ( rd * temperature )
+    if ( l_number_conc ) then
 
-    mconc_du_acc_ins(map_wth(1) + k) = acc_ins_du(map_wth(1) + k) * air_dens
-    mconc_du_cor_ins(map_wth(1) + k) = cor_ins_du(map_wth(1) + k) * air_dens
-
-    number_mr(1) = n_ait_sol(map_wth(1) + k)
-    number_mr(2) = n_acc_sol(map_wth(1) + k)
-    number_mr(3) = n_cor_sol(map_wth(1) + k)
-    number_mr(4) = n_ait_ins(map_wth(1) + k)
-    number_mr(5) = n_acc_ins(map_wth(1) + k)
-    number_mr(6) = n_cor_ins(map_wth(1) + k)
-
-    drydp(1) = max( drydp_ait_sol(map_wth(1) + k), drydp_min )
-    drydp(2) = max( drydp_acc_sol(map_wth(1) + k), drydp_min )
-    drydp(3) = max( drydp_cor_sol(map_wth(1) + k), drydp_min )
-    drydp(4) = max( drydp_ait_ins(map_wth(1) + k), drydp_min )
-    drydp(5) = max( drydp_acc_ins(map_wth(1) + k), drydp_min )
-    drydp(6) = max( drydp_cor_ins(map_wth(1) + k), drydp_min )
-
-    cn_sum       = 0.0_r_def
-    ccn_30nm_sum = 0.0_r_def
-    ccn_50nm_sum = 0.0_r_def
-
-    do imode = 1, nmodes_diag
+      ! Number density of air from pressure and temperature, matching
+      ! aird in ukca_mode_diags_mod
+      air_num_dens = pressure / ( temperature * boltzmann * m3_to_cm3 )
 
       ! Number mixing ratios are per air molecule, so scaling by the air
       ! number density gives particles per cubic centimetre
-      number_conc = number_mr(imode) * air_num_dens
+      number_conc(1) = n_ait_sol(map_wth(1) + k) * air_num_dens
+      number_conc(2) = n_acc_sol(map_wth(1) + k) * air_num_dens
+      number_conc(3) = n_cor_sol(map_wth(1) + k) * air_num_dens
+      number_conc(4) = n_ait_ins(map_wth(1) + k) * air_num_dens
+      number_conc(5) = n_acc_ins(map_wth(1) + k) * air_num_dens
+      number_conc(6) = n_cor_ins(map_wth(1) + k) * air_num_dens
 
-      cn_sum = cn_sum + 0.5_r_def * number_conc * ( 1.0_r_def -               &
-          erf( log( dp0_cn / drydp(imode) ) * recip_width(imode) ) )
+      drydp(1) = max( drydp_ait_sol(map_wth(1) + k), drydp_min )
+      drydp(2) = max( drydp_acc_sol(map_wth(1) + k), drydp_min )
+      drydp(3) = max( drydp_cor_sol(map_wth(1) + k), drydp_min )
+      drydp(4) = max( drydp_ait_ins(map_wth(1) + k), drydp_min )
+      drydp(5) = max( drydp_acc_ins(map_wth(1) + k), drydp_min )
+      drydp(6) = max( drydp_cor_ins(map_wth(1) + k), drydp_min )
 
-      ccn_30nm_sum = ccn_30nm_sum + 0.5_r_def * number_conc * ( 1.0_r_def -   &
-          erf( log( dp0_30nm / drydp(imode) ) * recip_width(imode) ) )
+      ! Condensation nuclei: dry diameter > 3 nm
+      if ( l_cn ) then
+        tail_sum = 0.0_r_def
+        do imode = 1, nmodes_diag
+          tail_sum = tail_sum + 0.5_r_def * number_conc(imode) *              &
+              ( 1.0_r_def - erf( log( dp0_cn / drydp(imode) )                 &
+                                 * recip_width(imode) ) )
+        end do
+        cn_number_conc(map_wth(1) + k) = tail_sum
+      end if
 
-      ccn_50nm_sum = ccn_50nm_sum + 0.5_r_def * number_conc * ( 1.0_r_def -   &
-          erf( log( dp0_50nm / drydp(imode) ) * recip_width(imode) ) )
+      ! Cloud condensation nuclei: dry diameter > 30 nm
+      if ( l_ccn_30nm ) then
+        tail_sum = 0.0_r_def
+        do imode = 1, nmodes_diag
+          tail_sum = tail_sum + 0.5_r_def * number_conc(imode) *              &
+              ( 1.0_r_def - erf( log( dp0_30nm / drydp(imode) )               &
+                                 * recip_width(imode) ) )
+        end do
+        ccn_number_conc_30nm(map_wth(1) + k) = tail_sum
+      end if
 
-    end do
+      ! Cloud condensation nuclei: dry diameter > 50 nm
+      if ( l_ccn_50nm ) then
+        tail_sum = 0.0_r_def
+        do imode = 1, nmodes_diag
+          tail_sum = tail_sum + 0.5_r_def * number_conc(imode) *              &
+              ( 1.0_r_def - erf( log( dp0_50nm / drydp(imode) )               &
+                                 * recip_width(imode) ) )
+        end do
+        ccn_number_conc_50nm(map_wth(1) + k) = tail_sum
+      end if
 
-    cn_number_conc(map_wth(1) + k)       = cn_sum
-    ccn_number_conc_30nm(map_wth(1) + k) = ccn_30nm_sum
-    ccn_number_conc_50nm(map_wth(1) + k) = ccn_50nm_sum
+    end if
+
+    !-------------------------------------------------------------------------
+    ! Dust mass concentrations: mass mixing ratio times the mass density of
+    ! dry air, as for the UKCA component mass concentrations in
+    ! ukca_mode_diags_mod
+    !-------------------------------------------------------------------------
+
+    if ( l_du_acc_ins .or. l_du_cor_ins ) then
+
+      air_dens = pressure / ( rd * temperature )
+
+      if ( l_du_acc_ins ) then
+        mconc_du_acc_ins(map_wth(1) + k) = acc_ins_du(map_wth(1) + k) *       &
+                                           air_dens
+      end if
+
+      if ( l_du_cor_ins ) then
+        mconc_du_cor_ins(map_wth(1) + k) = cor_ins_du(map_wth(1) + k) *       &
+                                           air_dens
+      end if
+
+    end if
 
   end do
 
+  !---------------------------------------------------------------------------
   ! The zeroth level is redundant for the GLOMAP fields, so set it to the
   ! same as the first level. It appears in the diagnostic output but is not
   ! used in model evolution.
-  cn_number_conc(map_wth(1))       = cn_number_conc(map_wth(1) + 1)
-  ccn_number_conc_30nm(map_wth(1)) = ccn_number_conc_30nm(map_wth(1) + 1)
-  ccn_number_conc_50nm(map_wth(1)) = ccn_number_conc_50nm(map_wth(1) + 1)
-  mconc_du_acc_ins(map_wth(1))     = mconc_du_acc_ins(map_wth(1) + 1)
-  mconc_du_cor_ins(map_wth(1))     = mconc_du_cor_ins(map_wth(1) + 1)
+  !---------------------------------------------------------------------------
+
+  if ( l_cn ) then
+    cn_number_conc(map_wth(1)) = cn_number_conc(map_wth(1) + 1)
+  end if
+  if ( l_ccn_30nm ) then
+    ccn_number_conc_30nm(map_wth(1)) = ccn_number_conc_30nm(map_wth(1) + 1)
+  end if
+  if ( l_ccn_50nm ) then
+    ccn_number_conc_50nm(map_wth(1)) = ccn_number_conc_50nm(map_wth(1) + 1)
+  end if
+  if ( l_du_acc_ins ) then
+    mconc_du_acc_ins(map_wth(1)) = mconc_du_acc_ins(map_wth(1) + 1)
+  end if
+  if ( l_du_cor_ins ) then
+    mconc_du_cor_ins(map_wth(1)) = mconc_du_cor_ins(map_wth(1) + 1)
+  end if
 
 end subroutine glomap_ccn_diag_code
 

--- a/interfaces/physics_schemes_interface/source/kernel/glomap_ccn_diag_kernel_mod.F90
+++ b/interfaces/physics_schemes_interface/source/kernel/glomap_ccn_diag_kernel_mod.F90
@@ -14,9 +14,9 @@
 !>
 !>            0.5 * nd * ( 1 - erf( ln(dp0/drydp) / (sqrt(2)*ln(sigmag)) ) )
 !>
-!>          summed over the modes. This reproduces the UM/UKCA diagnostics
-!>          m01s38i437 (dp0 = 3 nm), m01s38i700 (dp0 = 30 nm) and
-!>          m01s38i701 (dp0 = 50 nm), computed in ukca_aero_ctl.
+!>          summed over the modes. This gives the condensation nuclei count
+!>          (dp0 = 3 nm) and the cloud condensation nuclei counts at two
+!>          activation thresholds (dp0 = 30 nm and dp0 = 50 nm).
 !>
 !>          Only the six modes that carry a dry modal diameter in LFRic are
 !>          summed. The nucleation-soluble mode is omitted because LFRic has
@@ -24,12 +24,10 @@
 !>          30 nm and 50 nm thresholds but not at 3 nm, so the condensation
 !>          nuclei count is a low estimate under prognostic UKCA.
 !>
-!>          The dust mass concentrations reproduce m01s38i502 and m01s38i503
-!>          from ukca_mode_diags_mod, where the CMIP6 component mass
-!>          concentration reduces to the component mass mixing ratio times
-!>          the air density p / (Rd * T). They are computed here rather than
-!>          as an XIOS expression so that every operand is on the aerosol
-!>          mesh and uses the same pressure and temperature as UKCA.
+!>          The dust mass concentrations are the dust mass mixing ratios of
+!>          the accumulation and coarse insoluble modes multiplied by the
+!>          air density p / (Rd * T). They are computed here rather than as
+!>          an XIOS expression so that every operand is on the aerosol mesh.
 !>
 !>          Every output field is only populated when it has been requested
 !>          as a diagnostic; unrequested fields share the empty data array
@@ -306,8 +304,7 @@ subroutine glomap_ccn_diag_code( nlayers,                                      &
 
     if ( l_number_conc ) then
 
-      ! Number density of air from pressure and temperature, matching
-      ! aird in ukca_mode_diags_mod
+      ! Number density of air molecules from pressure and temperature
       air_num_dens = pressure / ( temperature * boltzmann * m3_to_cm3 )
 
       ! Number mixing ratios are per air molecule, so scaling by the air
@@ -363,8 +360,7 @@ subroutine glomap_ccn_diag_code( nlayers,                                      &
 
     !-------------------------------------------------------------------------
     ! Dust mass concentrations: mass mixing ratio times the mass density of
-    ! dry air, as for the UKCA component mass concentrations in
-    ! ukca_mode_diags_mod
+    ! dry air
     !-------------------------------------------------------------------------
 
     if ( l_du_acc_ins .or. l_du_cor_ins ) then

--- a/interfaces/physics_schemes_interface/source/kernel/glomap_ccn_diag_kernel_mod.F90
+++ b/interfaces/physics_schemes_interface/source/kernel/glomap_ccn_diag_kernel_mod.F90
@@ -23,6 +23,13 @@
 !>          no drydp_nuc_sol field; its contribution is negligible at the
 !>          30 nm and 50 nm thresholds but not at 3 nm, so the condensation
 !>          nuclei count is a low estimate under prognostic UKCA.
+!>
+!>          The dust mass concentrations reproduce m01s38i502 and m01s38i503
+!>          from ukca_mode_diags_mod, where the CMIP6 component mass
+!>          concentration reduces to the component mass mixing ratio times
+!>          the air density p / (Rd * T). They are computed here rather than
+!>          as an XIOS expression so that every operand is on the aerosol
+!>          mesh and uses the same pressure and temperature as UKCA.
 
 module glomap_ccn_diag_kernel_mod
 
@@ -48,12 +55,15 @@ module glomap_ccn_diag_kernel_mod
 
   type, public, extends(kernel_type) :: glomap_ccn_diag_kernel_type
     private
-    type(arg_type) :: meta_args(19) = (/                &
+    type(arg_type) :: meta_args(24) = (/                &
          arg_type(GH_FIELD,  GH_REAL, GH_WRITE, WTHETA), & ! cn_number_conc
          arg_type(GH_FIELD,  GH_REAL, GH_WRITE, WTHETA), & ! ccn_no_conc_30nm
          arg_type(GH_FIELD,  GH_REAL, GH_WRITE, WTHETA), & ! ccn_no_conc_50nm
+         arg_type(GH_FIELD,  GH_REAL, GH_WRITE, WTHETA), & ! mconc_du_acc_ins
+         arg_type(GH_FIELD,  GH_REAL, GH_WRITE, WTHETA), & ! mconc_du_cor_ins
          arg_type(GH_SCALAR, GH_REAL, GH_READ),          & ! p_zero
          arg_type(GH_SCALAR, GH_REAL, GH_READ),          & ! one_over_kappa
+         arg_type(GH_SCALAR, GH_REAL, GH_READ),          & ! rd
          arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! theta_in_wth
          arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! exner_in_wth
          arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! n_ait_sol
@@ -67,7 +77,9 @@ module glomap_ccn_diag_kernel_mod
          arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! drydp_cor_sol
          arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! drydp_ait_ins
          arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! drydp_acc_ins
-         arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA)  & ! drydp_cor_ins
+         arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! drydp_cor_ins
+         arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! acc_ins_du
+         arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA)  & ! cor_ins_du
          /)
     integer :: operates_on = CELL_COLUMN
   contains
@@ -79,7 +91,8 @@ module glomap_ccn_diag_kernel_mod
 contains
 
 !> @brief Sum the lognormal tail of each GLOMAP mode above three dry diameter
-!>        thresholds to give condensation and cloud condensation nuclei counts.
+!>        thresholds to give condensation and cloud condensation nuclei
+!>        counts, and convert the dust mass mixing ratios to concentrations.
 !> @param[in]     nlayers              The number of layers
 !> @param[in,out] cn_number_conc       Condensation nuclei number
 !!                                      concentration, dry diameter > 3 nm
@@ -87,9 +100,14 @@ contains
 !!                                      concentration, dry diameter > 30 nm
 !> @param[in,out] ccn_number_conc_50nm Cloud condensation nuclei number
 !!                                      concentration, dry diameter > 50 nm
+!> @param[in,out] mconc_du_acc_ins     Dust mass concentration in the
+!!                                      accumulation insoluble mode
+!> @param[in,out] mconc_du_cor_ins     Dust mass concentration in the
+!!                                      coarse insoluble mode
 !> @param[in]     p_zero               Reference surface pressure
 !> @param[in]     one_over_kappa       Reciprocal of the ratio of the gas
 !!                                      constant to the specific heat
+!> @param[in]     rd                   Gas constant for dry air
 !> @param[in]     theta_in_wth         Potential temperature field
 !> @param[in]     exner_in_wth         Exner pressure in potential
 !!                                      temperature space
@@ -109,6 +127,10 @@ contains
 !> @param[in]     drydp_ait_ins        Aitken insoluble mode dry diameter
 !> @param[in]     drydp_acc_ins        Accumulation insoluble mode dry diameter
 !> @param[in]     drydp_cor_ins        Coarse insoluble mode dry diameter
+!> @param[in]     acc_ins_du           Accumulation insoluble mode dust mass
+!!                                      mixing ratio
+!> @param[in]     cor_ins_du           Coarse insoluble mode dust mass
+!!                                      mixing ratio
 !> @param[in]     ndf_wth              Number of degrees of freedom per cell
 !!                                      for the potential temperature space
 !> @param[in]     undf_wth             Number of unique degrees of freedom
@@ -120,8 +142,11 @@ subroutine glomap_ccn_diag_code( nlayers,                                      &
                                  cn_number_conc,                               &
                                  ccn_number_conc_30nm,                         &
                                  ccn_number_conc_50nm,                         &
+                                 mconc_du_acc_ins,                             &
+                                 mconc_du_cor_ins,                             &
                                  p_zero,                                       &
                                  one_over_kappa,                               &
+                                 rd,                                           &
                                  theta_in_wth,                                 &
                                  exner_in_wth,                                 &
                                  n_ait_sol,                                    &
@@ -136,6 +161,8 @@ subroutine glomap_ccn_diag_code( nlayers,                                      &
                                  drydp_ait_ins,                                &
                                  drydp_acc_ins,                                &
                                  drydp_cor_ins,                                &
+                                 acc_ins_du,                                   &
+                                 cor_ins_du,                                   &
                                  ndf_wth, undf_wth, map_wth )
 
   use constants_mod,                   only: r_def, i_def
@@ -154,9 +181,12 @@ subroutine glomap_ccn_diag_code( nlayers,                                      &
   real(kind=r_def), intent(inout), dimension(undf_wth) :: cn_number_conc
   real(kind=r_def), intent(inout), dimension(undf_wth) :: ccn_number_conc_30nm
   real(kind=r_def), intent(inout), dimension(undf_wth) :: ccn_number_conc_50nm
+  real(kind=r_def), intent(inout), dimension(undf_wth) :: mconc_du_acc_ins
+  real(kind=r_def), intent(inout), dimension(undf_wth) :: mconc_du_cor_ins
 
   real(kind=r_def), intent(in) :: p_zero
   real(kind=r_def), intent(in) :: one_over_kappa
+  real(kind=r_def), intent(in) :: rd
 
   real(kind=r_def), intent(in), dimension(undf_wth) :: theta_in_wth
   real(kind=r_def), intent(in), dimension(undf_wth) :: exner_in_wth
@@ -172,6 +202,8 @@ subroutine glomap_ccn_diag_code( nlayers,                                      &
   real(kind=r_def), intent(in), dimension(undf_wth) :: drydp_ait_ins
   real(kind=r_def), intent(in), dimension(undf_wth) :: drydp_acc_ins
   real(kind=r_def), intent(in), dimension(undf_wth) :: drydp_cor_ins
+  real(kind=r_def), intent(in), dimension(undf_wth) :: acc_ins_du
+  real(kind=r_def), intent(in), dimension(undf_wth) :: cor_ins_du
 
   ! Internal variables
 
@@ -212,6 +244,9 @@ subroutine glomap_ccn_diag_code( nlayers,                                      &
   real(kind=r_def), dimension(nmodes_diag) :: drydp
 
   real(kind=r_def) :: exner_k        ! Exner pressure at this level
+  real(kind=r_def) :: pressure       ! Pressure at this level (Pa)
+  real(kind=r_def) :: temperature    ! Temperature at this level (K)
+  real(kind=r_def) :: air_dens       ! Mass density of air (kg m-3)
   real(kind=r_def) :: air_num_dens   ! Number density of air (cm-3)
   real(kind=r_def) :: number_conc    ! Number concentration of a mode (cm-3)
   real(kind=r_def) :: cn_sum         ! Running sum for dry diameter > 3 nm
@@ -229,17 +264,26 @@ subroutine glomap_ccn_diag_code( nlayers,                                      &
   end do
 
   !---------------------------------------------------------------------------
-  ! Sum the tail of each mode above the three thresholds
+  ! Sum the tail of each mode above the three thresholds, and convert the
+  ! dust mass mixing ratios to mass concentrations
   !---------------------------------------------------------------------------
 
   do k = 1, nlayers
 
+    exner_k     = exner_in_wth(map_wth(1) + k)
+    pressure    = p_zero * exner_k**one_over_kappa
+    temperature = exner_k * theta_in_wth(map_wth(1) + k)
+
     ! Number density of air from pressure and temperature, matching
     ! aird in ukca_mode_diags_mod
-    exner_k = exner_in_wth(map_wth(1) + k)
-    air_num_dens = p_zero * exner_k**one_over_kappa                           &
-                 / ( exner_k * theta_in_wth(map_wth(1) + k)                   &
-                     * boltzmann * m3_to_cm3 )
+    air_num_dens = pressure / ( temperature * boltzmann * m3_to_cm3 )
+
+    ! Mass density of dry air, as used for the UKCA component mass
+    ! concentrations in ukca_mode_diags_mod
+    air_dens = pressure / ( rd * temperature )
+
+    mconc_du_acc_ins(map_wth(1) + k) = acc_ins_du(map_wth(1) + k) * air_dens
+    mconc_du_cor_ins(map_wth(1) + k) = cor_ins_du(map_wth(1) + k) * air_dens
 
     number_mr(1) = n_ait_sol(map_wth(1) + k)
     number_mr(2) = n_acc_sol(map_wth(1) + k)
@@ -288,6 +332,8 @@ subroutine glomap_ccn_diag_code( nlayers,                                      &
   cn_number_conc(map_wth(1))       = cn_number_conc(map_wth(1) + 1)
   ccn_number_conc_30nm(map_wth(1)) = ccn_number_conc_30nm(map_wth(1) + 1)
   ccn_number_conc_50nm(map_wth(1)) = ccn_number_conc_50nm(map_wth(1) + 1)
+  mconc_du_acc_ins(map_wth(1))     = mconc_du_acc_ins(map_wth(1) + 1)
+  mconc_du_cor_ins(map_wth(1))     = mconc_du_cor_ins(map_wth(1) + 1)
 
 end subroutine glomap_ccn_diag_code
 

--- a/interfaces/physics_schemes_interface/source/kernel/glomap_ccn_diag_kernel_mod.F90
+++ b/interfaces/physics_schemes_interface/source/kernel/glomap_ccn_diag_kernel_mod.F90
@@ -26,8 +26,9 @@
 !>
 !>          The dust mass concentrations are the dust mass mixing ratios of
 !>          the accumulation and coarse insoluble modes multiplied by the
-!>          air density p / (Rd * T). They are computed here rather than as
-!>          an XIOS expression so that every operand is on the aerosol mesh.
+!>          dry air density, which is the density the mixing ratios are
+!>          defined against. They are computed here rather than as an XIOS
+!>          expression so that every operand is on the aerosol mesh.
 !>
 !>          Every output field is only populated when it has been requested
 !>          as a diagnostic; unrequested fields share the empty data array
@@ -67,9 +68,9 @@ module glomap_ccn_diag_kernel_mod
          arg_type(GH_FIELD,  GH_REAL, GH_WRITE, WTHETA), & ! mconc_du_cor_ins
          arg_type(GH_SCALAR, GH_REAL, GH_READ),          & ! p_zero
          arg_type(GH_SCALAR, GH_REAL, GH_READ),          & ! one_over_kappa
-         arg_type(GH_SCALAR, GH_REAL, GH_READ),          & ! rd
          arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! theta_in_wth
          arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! exner_in_wth
+         arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! rho_in_wth
          arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! n_ait_sol
          arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! n_acc_sol
          arg_type(GH_FIELD,  GH_REAL, GH_READ,  WTHETA), & ! n_cor_sol
@@ -111,9 +112,10 @@ contains
 !> @param[in]     p_zero               Reference surface pressure
 !> @param[in]     one_over_kappa       Reciprocal of the ratio of the gas
 !!                                      constant to the specific heat
-!> @param[in]     rd                   Gas constant for dry air
 !> @param[in]     theta_in_wth         Potential temperature field
 !> @param[in]     exner_in_wth         Exner pressure in potential
+!!                                      temperature space
+!> @param[in]     rho_in_wth           Dry air density in potential
 !!                                      temperature space
 !> @param[in]     n_ait_sol            Aitken soluble mode number mixing ratio
 !> @param[in]     n_acc_sol            Accumulation soluble mode number
@@ -150,9 +152,9 @@ subroutine glomap_ccn_diag_code( nlayers,                                      &
                                  mconc_du_cor_ins,                             &
                                  p_zero,                                       &
                                  one_over_kappa,                               &
-                                 rd,                                           &
                                  theta_in_wth,                                 &
                                  exner_in_wth,                                 &
+                                 rho_in_wth,                                   &
                                  n_ait_sol,                                    &
                                  n_acc_sol,                                    &
                                  n_cor_sol,                                    &
@@ -192,10 +194,10 @@ subroutine glomap_ccn_diag_code( nlayers,                                      &
 
   real(kind=r_def), intent(in) :: p_zero
   real(kind=r_def), intent(in) :: one_over_kappa
-  real(kind=r_def), intent(in) :: rd
 
   real(kind=r_def), intent(in), dimension(undf_wth) :: theta_in_wth
   real(kind=r_def), intent(in), dimension(undf_wth) :: exner_in_wth
+  real(kind=r_def), intent(in), dimension(undf_wth) :: rho_in_wth
   real(kind=r_def), intent(in), dimension(undf_wth) :: n_ait_sol
   real(kind=r_def), intent(in), dimension(undf_wth) :: n_acc_sol
   real(kind=r_def), intent(in), dimension(undf_wth) :: n_cor_sol
@@ -252,7 +254,6 @@ subroutine glomap_ccn_diag_code( nlayers,                                      &
   real(kind=r_def) :: exner_k        ! Exner pressure at this level
   real(kind=r_def) :: pressure       ! Pressure at this level (Pa)
   real(kind=r_def) :: temperature    ! Temperature at this level (K)
-  real(kind=r_def) :: air_dens       ! Mass density of air (kg m-3)
   real(kind=r_def) :: air_num_dens   ! Number density of air (cm-3)
   real(kind=r_def) :: tail_sum       ! Running sum over the modes
 
@@ -359,24 +360,17 @@ subroutine glomap_ccn_diag_code( nlayers,                                      &
     end if
 
     !-------------------------------------------------------------------------
-    ! Dust mass concentrations: mass mixing ratio times the mass density of
-    ! dry air
+    ! Dust mass concentrations: mass mixing ratio times the dry air density
     !-------------------------------------------------------------------------
 
-    if ( l_du_acc_ins .or. l_du_cor_ins ) then
+    if ( l_du_acc_ins ) then
+      mconc_du_acc_ins(map_wth(1) + k) = acc_ins_du(map_wth(1) + k) *         &
+                                         rho_in_wth(map_wth(1) + k)
+    end if
 
-      air_dens = pressure / ( rd * temperature )
-
-      if ( l_du_acc_ins ) then
-        mconc_du_acc_ins(map_wth(1) + k) = acc_ins_du(map_wth(1) + k) *       &
-                                           air_dens
-      end if
-
-      if ( l_du_cor_ins ) then
-        mconc_du_cor_ins(map_wth(1) + k) = cor_ins_du(map_wth(1) + k) *       &
-                                           air_dens
-      end if
-
+    if ( l_du_cor_ins ) then
+      mconc_du_cor_ins(map_wth(1) + k) = cor_ins_du(map_wth(1) + k) *         &
+                                         rho_in_wth(map_wth(1) + k)
     end if
 
   end do

--- a/rose-stem/app/lfric_atm/file/file_def_diags_gal_clim_chem.xml
+++ b/rose-stem/app/lfric_atm/file/file_def_diags_gal_clim_chem.xml
@@ -83,6 +83,11 @@
       <field field_ref="aerosol__acc_ins_du" />
       <field field_ref="aerosol__cor_ins_du" />
       <field field_ref="aerosol__cloud_drop_no_conc" />
+      <field field_ref="aerosol__mconc_du_acc_ins" />
+      <field field_ref="aerosol__mconc_du_cor_ins" />
+      <field field_ref="aerosol__cn_number_conc" />
+      <field field_ref="aerosol__ccn_number_conc_30nm" />
+      <field field_ref="aerosol__ccn_number_conc_50nm" />
     </field_group>
 
     <!-- 2D fields averaged every timestep -->

--- a/science/gungho/source/algorithm/physics/slow_physics_alg_mod.X90
+++ b/science/gungho/source/algorithm/physics/slow_physics_alg_mod.X90
@@ -542,8 +542,13 @@ contains
                ( glomap_mode == glomap_mode_dust_and_clim ) ) .and.  &
              ( ( activation_scheme == activation_scheme_jones ) .or. &
                ( l_radaer ) ) ) then
-          call glomap_aerosol_alg ( aerosol_fields, cloud_fields, theta_aero,       &
-                                    exner_in_wth_aero, mr_n_aero, clock%get_step() )
+          call glomap_aerosol_alg ( aerosol_fields,                            &
+                                    cloud_fields,                              &
+                                    theta_aero,                                &
+                                    exner_in_wth_aero,                         &
+                                    rho_in_wth_aero,                           &
+                                    mr_n_aero,                                 &
+                                    clock%get_step() )
         end if
 
         !--------------------------------------------------------------------


### PR DESCRIPTION
# PR Summary



Sci/Tech Reviewer: <!-- SR id, filled by author when ready for review (e.g. @octocat) -->
Code Reviewer: @stevemullerworth 

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->
Diagnostics implemented
-----------------------
| # | Field id                        | NetCDF name           | Units  | Group                        |
|---|---------------------------------|-----------------------|--------|------------------------------|
| 1 | aerosol__mconc_du_acc_ins       | mconc_du_acc_ins      | kg m-3 | A - XML Expression           |
| 2 | aerosol__mconc_du_cor_ins       | mconc_du_cor_ins      | kg m-3 | A - XML Expression           |
| 3 | aerosol__cn_number_conc         | cn_number_conc        | cm-3   | E + H - Computed-at-Output,  |
|   |                                 |                       |        | Mutual Dependency            |
| 4 | aerosol__ccn_number_conc_30nm   | ccn_number_conc_30nm  | cm-3   | E + H                        |
| 5 | aerosol__ccn_number_conc_50nm   | ccn_number_conc_50nm  | cm-3   | E + H                        |

Corresponding UM STASH: m01s38i502, m01s38i503, m01s38i437, m01s38i700,
m01s38i701. All are on model theta levels (Wtheta / full_level_face_grid).

Not implemented (3 of the 8 requested in the issue)
---------------------------------------------------
| STASH      | Requested diagnostic                  | Why not implemented                          |
|------------|---------------------------------------|----------------------------------------------|
| m01s38i500 | Dust, accumulation soluble mode       | Mixing ratio hard-wired to zero in LFRic;     |
|            |                                       | no backing field exists                       |
| m01s38i501 | Dust, coarse soluble mode             | As above                                      |
| m01s38i696 | Dust, super-coarse insoluble mode     | Mode absent from the i_sussbcocdu_7mode setup |

Evidence for each is recorded in docs/plan/plan-issue-739.md. Dropping
these three was agreed before implementation began; they need new LFRic
prognostic fields (or an extended mode setup) before the diagnostics can
be written, which is out of scope for a diagnostics ticket.


Implementation
--------------
The bundle spans two groups.

The two dust mass concentrations are pure XIOS expression fields with zero
Fortran. UKCA's CMIP6 component mass concentration calculation
(ukca_mode_diags_mod, mode_diags_cmip6) reduces algebraically to the
component mass mixing ratio multiplied by the air density, so each entry
is written directly as `aerosol__<mode>_du * rho_in_wth` in the registry.

The three number concentrations share one Group E implementation. A new
diagnostics module runs entirely inside the existing output guard and, when
any of the three fields is requested, calls a new kernel that sums the
lognormal tail

    0.5 * nd * ( 1 - erf( ln(dp0/drydp) / (sqrt(2) * ln(sigma_g)) ) )

over the six GLOMAP modes that carry a dry modal diameter in LFRic, with
dp0 = 3 nm, 30 nm and 50 nm respectively. Number density is recovered as
number mixing ratio times air number density, the latter derived in the
kernel from Exner and potential temperature with p_zero and one_over_kappa
passed in as scalar arguments (kernels may not `use` module variables).

Per-diagnostic notes:
- aerosol__cn_number_conc: excludes the nucleation-soluble mode, because
  LFRic has no drydp_nuc_sol field. This is stated explicitly in the
  field's long_name so the difference from the UM diagnostic is visible in
  the output metadata.
- All three: modifier H applies. One kernel call fills all three fields, so
  if any one is requested the other two are force-activated with
  `activate = .true.` and simply not written. This avoids a three-way
  branch in the algorithm layer.
- The diagnostics module is wired into both GLOMAP paths (the climatology
  path in glomap_aerosol_alg_mod and the prognostic UKCA path in
  aerosol_ukca_alg_mod). It derives its mesh from an input field via
  `force_mesh` rather than from the diagnostic metadata, because under
  coarse_rad_aerosol the aerosol scheme runs on a coarser mesh.
- On the climatology path drydp_* is only refreshed on RADAER timesteps.
  This is documented in the diagnostics module rather than enforced at
  runtime; requesting these diagnostics at a higher frequency than the
  radiation timestep will repeat the last radiation-timestep diameters.

Files changed:
- applications/lfric_atm/metadata/field_def_diags.xml: five new <field>
  entries in the aerosol group (two XIOS expressions, three plain fields).
- interfaces/physics_schemes_interface/source/kernel/glomap_ccn_diag_kernel_mod.F90:
  new kernel computing the lognormal tail sum over the six GLOMAP modes.
- interfaces/physics_schemes_interface/source/diagnostics/glomap_ccn_diags_mod.x90:
  new diagnostics module - init_diag, mutual-dependency activation, single
  grouped invoke, guarded write_field.
- interfaces/physics_schemes_interface/source/algorithm/glomap_aerosol_alg_mod.x90:
  call the new diagnostics module from the climatology path.
- interfaces/physics_schemes_interface/source/algorithm/aerosol_ukca_alg_mod.x90:
  call the new diagnostics module from the prognostic UKCA path.
- CONTRIBUTORS.md: add zmaalick (Zubair Maalick, Met Office).


Similar existing diagnostics
----------------------------
aerosol__pvol_du_cor_ins (and the rest of the aerosol__pvol_* family) is
the closest analogue for the two dust mass concentrations: same section,
same grid, same GLOMAP mode decomposition, and the same pattern of one
registry entry per mode.

microphysics__dt_mphys is the closest analogue for the CN/CCN group - a
Group E diagnostic whose whole computation lives inside the output routine
because the quantities it needs are only assembled at output time.


Code Review
-----------
Reviewed by Fable 5 against the LFRic Fortran coding standards.
Verdict: APPROVED WITH ADVISORIES (round 1 of 3)

Advisory notes:
1. The six sigma_g values are hard-coded in the kernel as named parameters,
   copied from the UKCA i_sussbcocdu_7mode setup. If a different GLOMAP
   mode configuration were ever selected they would silently be wrong. The
   reviewer suggested passing them as scalar arguments from the algorithm
   layer. Not changed: the LFRic GLOMAP configuration is fixed at
   i_sussbcocdu_7mode, and the provenance is documented in a comment.
2. erf is a Fortran 2008 intrinsic. The UM interface layer provides a
   umErf wrapper because intrinsic erf support historically varied, but
   calling it would violate the kernel rule against calling other modules'
   procedures. The intrinsic is the correct trade-off here; worth
   confirming all target compilers accept intrinsic erf in kernel code.
3. `end type` should name the type. Fixed.
4. The comment justifying the written-out sqrt(2) literal was imprecise.
   Reworded. Fixed.

Advisories 3 and 4 were applied before the commit; 1 and 2 are recorded
here as deliberate decisions.


Testing
-------
- diag_tool.py check passes: 1436 field ids defined, all code-referenced
  ids defined in XML, no mismatches.
- field_def_diags.xml parses as well-formed XML.
- New Fortran and .x90 files: no trailing whitespace, all lines within 80
  columns, copyright headers present, kinds on all reals and real literals.
- Kernel meta_args order verified 1:1 against the subroutine argument list
  (19 metadata arguments; outputs first, intent(inout), GH_WRITE).
- Both call sites verified: all 14 actual arguments exist and are correctly
  typed at each site; state(igh_t) is potential temperature on Wtheta.

Not yet done - requires a model run:
- Confirm the five fields appear in NetCDF output when requested in the
  iodef, with the expected magnitudes (CN typically 1e2-1e4 cm-3 in the
  boundary layer, CCN a fraction of that; dust mass concentrations
  1e-10-1e-7 kg m-3).
- Compare against the equivalent UM STASH output for a matched case.
- No rose-stem changes are included; per the project workflow, rose-stem
  is out of scope for diagnostic implementations.


Related
-------
Issue: https://github.com/MetOffice/lfric_apps/issues/739
Plan:  docs/plan/plan-issue-739.md
Log:   docs/log/log-739.md
<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [ ] Comments have been included that aid understanding and enhance the readability of the code
- [ ] My changes generate no new warnings
- [ ] All automated checks in the CI pipeline have completed successfully

## Testing

- [ ] I have tested this change locally, using the LFRic Apps rose-stem suite
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

## Security Considerations

- [ ] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [HPC Optimisation Team](mailto:ML-NC-Prediction-SMIT-HPCOptimisation@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
